### PR TITLE
Code comments should focus on why, not how.

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,11 +314,17 @@ developing in Ruby.
 
 ## Comments
 
-* Comments longer than a word are capitalized and use punctuation.
+* Good comments focuses on the reader of the code, by helping them understand the code. The reader may not have the same understanding, experience and knowledge as you. As a writer, take this into account.
 
-* Avoid superfluous comments.
+* A big problem with comments is that they can get out of sync with the code easily. When refactoring code, refactor the surrounding comments are refactored as well.
 
-* If you really need them, could you instead clarify your code?
+* Write good copy, and use proper capitalization and punctuation.
+
+* Focus on **why** your code is the way it is if this is not obvious, not **how** your code works.
+
+* Avoid superfluous comments. If they are about how your code works, should you clarify your code instead?
+
+* For a good discussion on the costs and benefits of comments, see http://c2.com/cgi/wiki?CommentCostsAndBenefits.
 
 
 ## Classes & Modules


### PR DESCRIPTION
The comments section now only contains reasons why you should not use comments, and not why you should use them. To counter that balance, I added a line that says code comments should focus on why, not the what and how.

I created this PR to start a discussion, because how we treat comments is a bit of a pet peeve of mine. The default is that all comments should be removed. I have seen too many PRs with code reviews like "just remove the comments and you're good to go". The style guide currently reinforces this by only talking about bad comments. Let's figure out what we think are good comments, and encourage people to add them
