### PR TITLE
Enforce conditional expression alignment on assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,30 @@ developing in Ruby.
 
 * Indent `when` as deep as `case`.
 
+* When assigning the result of a conditional expression to a variable, align its
+  branches with the variable that receives the return value.
+
+    ```ruby
+    # bad
+    result =
+      if some_cond
+        # ...
+        # ...
+        calc_something
+      else
+        calc_something_else
+      end
+
+    # good
+    result = if some_cond
+      # ...
+      # ...
+      calc_something
+    else
+      calc_something_else
+    end
+    ```
+
 * Use empty lines between method definitions and also to break up methods into
   logical paragraphs internally.
 


### PR DESCRIPTION
We currently don't mention anything about it and I think it would be nice to enforce a style for consistency.

According to the Community Style Guide (https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment), the block should be aligned with the conditional itself, and not with the variable being assigned. 

Usually I follow that rule when writing Ruby but I don't have a strong preference for any. I'm creating this PR mostly to start a discussion and decide what style we should adopt. 
