### PR TITLE
Fix markdown alignment on the Test section

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,48 +888,50 @@ developing in Ruby.
 * A test case should only test a single aspect of your code.
 
 * A good test case consists of three parts:
+    1. Setup of the environment
+    2. The action that is the subject of the test
+    3. Asserting that the action did what you expect it do to.
 
-  1. Setup of the environment
-  2. The action that is the subject of the test
-  3. Asserting that the action did what you expect it do to.
+    Consider separating these parts by a newline for readability, especially
+    when your environment setup is complicated and you want to run multiple
+    assertions afterwards.
 
-  Consider separating these parts by a newline for readability, especially
-  when your environment setup is complicated and you want to run multiple assertions
-  afterwards.
+    ```ruby
+    test 'sending a password reset email clears the password hash and set a reset token' do
+      user = User.create!(email: 'bob@example.com')
+      user.mark_as_verified
 
-  ```ruby
-  test 'sending a password reset email clears the password hash and set a reset token' do
-    user = User.create!(email: 'bob@example.com')
-    user.mark_as_verified
+      user.send_password_reset_email
 
-    user.send_password_reset_email
+      assert_nil user.password_hash
+      refute_nil user.reset_token
+    end
+    ```
 
-    assert_nil user.password_hash
-    refute_nil user.reset_token
-  end
-  ```
+* A complex test should be split into multiple simpler tests that test
+  functionality in isolation.
 
-* A complex test should be split into multiple simpler tests that test functionality in isolation.
+* Prefer using `test 'foo'`-style syntax to define test cases over
+  `def test_foo`.
 
-* Prefer using `test 'foo'`-style syntax to define test cases over `def test_foo`.
+* Prefer using assertion methods that will yield a more descriptive error
+  message.
 
-* Prefer using assertion methods that will yield a more descriptive error message.
-
-  ```ruby
-  # bad
-  assert user.valid?
-  assert user.name == 'tobi'
+    ```ruby
+    # bad
+    assert user.valid?
+    assert user.name == 'tobi'
 
 
-  # good
-  assert_predicate user, :valid?
-  assert_equal 'tobi', user.name
-  ```
+    # good
+    assert_predicate user, :valid?
+    assert_equal 'tobi', user.name
+    ```
 
 * Avoid using `assert_nothing_raised`. Use a positive assertion instead.
 
-* Prefer using assertions over expectations. Expectations lead to more brittle tests,
-  especially in combination with singleton objects.
+* Prefer using assertions over expectations. Expectations lead to more brittle
+  tests, especially in combination with singleton objects.
 
     ```ruby
     # bad


### PR DESCRIPTION
### Before

![image](https://cloud.githubusercontent.com/assets/301187/12531414/f5b59cb0-c1c7-11e5-854a-a7cbd09269af.png)
### After

![image](https://cloud.githubusercontent.com/assets/301187/12531416/007a0d84-c1c8-11e5-9e6f-6efde9d7994f.png)

Also, lines are limited to 80 chars when possible.

cc @wvanbergen 
