### PR TITLE
Align `when` with the start of the `case` line when used in an assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ developing in Ruby.
 
 * No space inside range literals.
 
-* Indent `when` as deep as `case`.
+* Indent `when` as deep as the `case` line.
 
 * When assigning the result of a conditional expression to a variable, align its
   branches with the variable that receives the return value.


### PR DESCRIPTION
Currently we say

> - Indent `when` as deep as `case`.

which when used as an assignment would enforce

``` ruby
result = case operation
         when :add
           x + y
         when :multiply
           x * y
         else
           raise NotImplementedError
         end
```

however, we also say

> - When assigning the result of a conditional expression to a variable, align its
>   branches with the variable that receives the return value.

which is inconsistent with the indentation for `case` and `when`.

Instead, we should avoid special casing the indentation for `case` as an expression in an assignment and suggest the following should be used

``` ruby
result = case operation
when :add
  x + y
when :multiply
  x * y
else
  raise NotImplementedError
end
```

by saying

> Indent `when` as deep as the `case` line.

Note that the output of `git grep -A5 -n ' = case'` shows that this change is consistent with our existing codebase in Shopify core.
