### PR TITLE
Give an example for multi-line rails scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,17 +207,20 @@ developing in Ruby.
   (e.g. `attr_reader`, `puts`) and attribute access methods. Use parentheses
   around the arguments of all other method invocations.
 
-  Due to `{` having a higher precedence than `do` you may need to use parenthesis
-  to DSL calls to pass a multi-line lambda as an argument to the call.
+* Use class methods instead of a rails scope with a multi-line lambda
 
     ```ruby
-    # good
-    scope :pending, -> { where(pending: true) }
-
+    # bad
     scope(:pending, lambda do
       ...
       ...
     end)
+
+    # good
+    def self.pending
+      ...
+      ...
+    end
     ```
 
 * Omit the outer braces around an implicit options hash.


### PR DESCRIPTION
cc @mlhamel
## Problem

Currently our ruby style guide suggests that scope with a multi-line block is done as follows

``` ruby
  scope :cleanable, lambda do
  …
  end
```

based on the following statements in the style guide:

> - Omit parentheses around parameters for methods that are part of an internal DSL (e.g. Rake, Rails, RSpec), methods that have "keyword" status in Ruby (e.g. `attr_reader`, `puts`) and attribute access methods. Use parentheses around the arguments of all other method invocations.
> - Prefer `{...}` over `do...end` for single-line blocks. Avoid using `{...}` for multi-line blocks. Always use `do...end` for "control flow" and "method definitions" (e.g. in Rakefiles and certain DSLs). Avoid `do...end` when chaining.
> - Use the new lambda literal syntax for single-line body blocks. Use the lambda method for multi-line blocks.

However, the combination of these suggestions mean that the block for the lambda ends up getting applied to the `scope` call, rather than being passed to `lambda` to construct the lambda in order to pass it as an argument, which means the code doesn't work.  Thus an exception to either one of those rules is needed to write code that works in a situation like this.
## Solution

Suggest for this case, since that is compatible with the style currently enforced by .rubocop.yml

``` ruby
  scope(:cleanable, lambda do
  …
  end)
```

I decided to add the example to the one about the DSL methods not using parenthesis, since that is the rule that this is an exception to.
