### PR TITLE
Use the indented style for MultilineMethodCallIndentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ developing in Ruby.
     end
     ```
 
+* When chaining methods on multiple lines, indent successive calls by one level of indentation.
+
+    ```ruby
+    # bad (indented to the previous call)
+    User.pluck(:name)
+        .sort(&:casecmp)
+        .chunk { |n| n[0] }
+
+    # good
+    User
+      .pluck(:name)
+      .sort(&:casecmp)
+      .chunk { |n| n[0] }
+    ```
+
 * Align the elements of array literals spanning multiple lines.
 
 * Limit lines to 120 characters.

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -73,3 +73,7 @@ Performance/Casecmp:
 
 Style/AsciiComments:
   Enabled: false
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  IndentationWidth: 2


### PR DESCRIPTION
Prefer

``` ruby
User.pluck(:name)
  .select { |n| n.start_with?("A") }
  .sample(5)
```

to

``` ruby
User.pluck(:name)
    .select { |n| n.start_with?("A") }
    .sample(5)
```

Stats from https://github.com/Shopify/shopify:

```
❯ rubocop --only "Style/MultilineMethodCallIndentation" --format offenses **/*.rb
```

| `EnforcedStyle: aligned` (default) | `EnforcedStyle: indented` |
| --- | --- |
| 325 | 133 |
