### PR TITLE
Use the same array indentation style as with hashes.

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -31,6 +31,9 @@ Style/NumericLiterals:
 Style/CaseIndentation:
   IndentWhenRelativeTo: end
 
+Style/IndentArray:
+  EnforcedStyle: consistent
+
 Style/IndentHash:
   EnforcedStyle: consistent
 


### PR DESCRIPTION
We changed the indentation style for hashes, but not for arrays, which causes an inconsistency.

For instance, rubocop would try to enforce the style

``` ruby
wolverine.reservations.reserve([
                                 cart_id_from_token(cart_token),
                                 items_to_quantities.to_json,
                                 current_time.to_i,
                                 expiry_in_seconds.to_i,
                                 VARIANT_KEY_EXPIRATION_BUFFER,
                                 ignore_inventory_policy ? 1 : 0,
                                 shard_id
                               ])
```

instead of

```
wolverine.reservations.reserve([
  cart_id_from_token(cart_token),
  items_to_quantities.to_json,
  current_time.to_i,
  expiry_in_seconds.to_i,
  VARIANT_KEY_EXPIRATION_BUFFER,
  ignore_inventory_policy ? 1 : 0,
  shard_id
])
```

so this pull request changes it to prefer the latter
