### PR TITLE
Don't force alignment of implicit hash params

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -37,6 +37,9 @@ Style/IndentArray:
 Style/IndentHash:
   EnforcedStyle: consistent
 
+Style/AlignHash:
+  EnforcedLastArgumentHashStyle: ignore_implicit
+
 Metrics/AbcSize:
   Enabled: false
 


### PR DESCRIPTION
By default rubocop required the following:

```
foo(bar, baz, baq, option: 1,
                   option: 2)
```

because it requires alignment of hash keys, which is silly. Tell it to ignore
alignment only for implicit hash method parameters.

@etiennebarrie @Soleone @cjoudrey 
