### PR TITLE
Allow trivial predicate accessors

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -86,3 +86,6 @@ Style/MultilineMethodCallIndentation:
 
 Metrics/LineLength:
   Max: 120
+
+Style/TrivialAccessors:
+  AllowPredicates: true


### PR DESCRIPTION
> Use the `attr` family of methods to define trivial accessors or mutators.

Agreed, but for predicate accessors we can't use the `attr` family:

``` ruby
attr_writer :foo

def foo?
  @foo
end
```

@volmer @sgnr 
