### PR TITLE
Disable trailing underscore variable cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -84,5 +84,8 @@ Style/MultilineMethodCallIndentation:
   EnforcedStyle: indented
   IndentationWidth: 2
 
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
 Metrics/LineLength:
   Max: 120


### PR DESCRIPTION
We don't mention anything in our style guide about this (do we want to?), but Rubocop prevents doing this:

``` ruby
a, _ = foo
```

and prefers

``` ruby
a, = foo
```

which seems less readable.

Also `_` maps nicely to `*` as in:

``` ruby
a, * = foo
```

@wvanbergen @volmer 
