### PR TITLE
disable module length check

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -52,6 +52,9 @@ Style/StringLiterals:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 Metrics/MethodLength:
   Enabled: false
 


### PR DESCRIPTION
This disables the style violation on module length. 100 lines is not realistic, particularly when it comes to test concerns for example. @volmer 
