### PR TITLE
Disable Closing Parenthesis Identation

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -4,6 +4,9 @@ Lint/AssignmentInCondition:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/ClosingParenthesisIndentation:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
While it should be enabled, this one causes a bit of grief when using implicit hash as last parameters.

This works before this PR:

``` ruby
foo(bar,
  param: {
    something: 1,
  },
  other: 42)
```

as well as:

``` ruby
foo(
  bar,
  param: {
    something: 1,
  },
  other: 42,
)
```

but not this:

``` ruby
foo(bar,
  param: {
    something: 1,
  },
  other: 42,
)
```

which can often happen if you start out with 

``` ruby
foo(bar, {
  param: {
    something: 1,
  },
  other: 42,
})
```

which Rubocop rightly complains about ("Omit the outer braces around an implicit options hash").

I think the first version makes sense, I understand that second version seems less readable (think `BackgroundQueue.push(Maintenance::SomeMaintenanceTask,`, although [the template doesn't demonstrate this issue](https://github.com/Shopify/shopify/blob/master/lib/generators/maintenance_task/templates/migration.rb.erb)), but the third version should be acceptable as well.

Disabling the cop is a bit annoying, ideally it would not fail or it would be configurable to not fail, because at this point using `Style/AlignParameters` `with_fixed_indentation` makes no sense, it asks you to indent like this:

``` ruby
foo(bar,
  param: {
    something: 1,
  },
  other: 42,
   )
```
