### PR TITLE
Encourage `extend self` over `module_function`

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ developing in Ruby.
 
 * Avoid superfluous comments. If they are about how your code works, should you clarify your code instead?
 
-* For a good discussion on the costs and benefits of comments, see 
+* For a good discussion on the costs and benefits of comments, see
   [http://c2.com/cgi/wiki?CommentCostsAndBenefits](http://c2.com/cgi/wiki?CommentCostsAndBenefits).
 
 
@@ -389,21 +389,21 @@ developing in Ruby.
 
   ~~~ ruby
   # bad
-  class SomeClass
-    def self.some_method
-      # body omitted
+  module SomeModule
+    module_function
+
+    def some_method
     end
 
-    def self.some_other_method
+    def some_other_method
     end
   end
 
   # good
   module SomeModule
-    module_function
+    extend self
 
     def some_method
-      # body omitted
     end
 
     def some_other_method
@@ -411,7 +411,7 @@ developing in Ruby.
   end
   ~~~
 
-* Favor the use of `module_function` over `extend self` when you want to turn a
+* Favor the use of `extend self` over `module_function` when you want to turn a
   module's instance methods into class methods.
 
 * When designing class hierarchies make sure that they conform to the [Liskov

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -92,3 +92,6 @@ Style/TrailingUnderscoreVariable:
 
 Metrics/LineLength:
   Max: 120
+
+Style/ModuleFunction:
+  Enabled: false


### PR DESCRIPTION
@etiennebarrie @volmer @dylanahsmith @eapache @rafaelfranca 

Remove the `Style/ModuleFunction` which forces `module_function` over `extend self`.

Recommend using `class << self` as a generalized solution for class methods inside classes, or modules that _only_ contain class level methods.

Both `class << self` and `extend self` are used extensively in Shopify/shopify, much more than `module_function`, and will respect `private`/`protected` like `def self.` will not.

Discussed in _#ruby-style-guide_. 
