### PR TITLE
Reinstate and/or for flow control

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ developing in Ruby.
 
 * Use `!` instead of `not`.
 
-* Don't use `and` and `or` keywords. Always use `&&` and `||` instead.
+* Prefer `&&`/`||` over `and`/`or`.
+  [More info on `and/or` for control flow](http://devblog.avdi.org/2014/08/26/how-to-use-rubys-english-andor-operators-without-going-nuts/).
 
 * Avoid multiline `?:` (the ternary operator); use `if/unless` instead.
 


### PR DESCRIPTION
In #4 `and`/`or` were rendered illegal because reasons. The "community" ruby style guide has no arguments apart from ["it's not worth it"](https://github.com/bbatsov/ruby-style-guide#no-and-or-or), and we used to have a link explaining quite well how it can be useful. I brought all that back.

I also disabled the cop. I wish I didn't have too, but since the bbatsov style guide is against control flow `and` and `or`, Rubocop doesn't have an option to handle it the right way. Or we can keep the cop but accept that people will have to merge red branches because of it, I don't have a strong opinion on that part.
