### PR TITLE
Avoid use of `::` when defining classes and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,32 @@ developing in Ruby.
 
 ## Syntax
 
-* Use `::` only to reference constants(this includes classes and modules) and
+* Use `::` only to reference constants (this includes classes and modules) and
   constructors (like `Array()` or `Nokogiri::HTML()`). Do not use `::` for
   regular method invocation.
+
+* Avoid using `::` for defining class and modules, or for inheritance, since
+  constant lookup will not search in parent classes/modules.
+
+  ~~~ ruby
+  # bad
+  module A
+    FOO = 'test'
+  end
+
+  class A::B
+    puts FOO  # this will raise a NameError exception
+  end
+
+  # good
+  module A
+    FOO = 'test'
+
+    class B
+      puts FOO
+    end
+  end
+  ~~~
 
 * Use def with parentheses when there are parameters. Omit the parentheses when
   the method doesn't accept any parameters.

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,9 +1,6 @@
 Lint/AssignmentInCondition:
   Enabled: false
 
-Style/ClassAndModuleChildren:
-  Enabled: false
-
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
@kmcphillips @volmer @rafaelfranca + feel free to ping anyone else you think may have some insight here.

I found this terribly confusing. I think that the namespace resolution operator should probably only ever be used for lookup. I know this is basically stated in the point above the one I'm adding, but I really wanted to call this out in some fashion.

There was one issue we encountered in Shipify where I saw this similar behaviour (i.e., the module nesting being different in the two cases), but for inheritance. We have a inheritance chain of `CanadaPostShipify < CanadaPostPWS < Carrier`, all of these in the active shipping module. We inherited from `ActiveShipping::CanadaPostPWS` for `CanadaPostShipify`, but it could not find some methods defined on `Carrier`. The fix was to not use the namespace resolution operator (see [this](https://github.com/Shopify/shipify/commit/f185e2a1639ef23031126f0503773e2315f3d360) commit).

Unfortunately, I have not been able to create an MVP for the inheritance case, so maybe others can shed some light on it. I just wanted to push out this PR for discussion while I try to reproduce. If it _is_ an issue though, it shows that the point above the one I'm adding is insufficient, since `class A < B::C` adheres to that rule (i.e., `B::C` is constant reference).
