### PR TITLE
Allow double negation

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -95,3 +95,6 @@ Metrics/LineLength:
 
 Style/ModuleFunction:
   Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false


### PR DESCRIPTION
Just got hit with this in a PR and @t6d along with @kmcphillips agreed we should not ban the bang bang. Some people disagree: https://github.com/bbatsov/ruby-style-guide#no-bang-bang

I don't feel strongly either way - but we do use `!!` in shopify quite a bit so unless we really dislike I think we should disable the rule.

```
~/src/github.com/Shopify/shopify$ grep -r -i --include *.rb '!!' ./ | wc -l
     150
```
