### PR TITLE
Enable arbitrarily long lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,6 @@ developing in Ruby.
 
 * Align the elements of array literals spanning multiple lines.
 
-* Limit lines to 120 characters.
-
 * Avoid trailing whitespace.
 
 * Avoid extra whitespace, except for alignment purposes.

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -103,7 +103,7 @@ Style/TrailingUnderscoreVariable:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 120
+  Enabled: false
 
 Style/ModuleFunction:
   Enabled: false


### PR DESCRIPTION
Three reasons I see long lines come up:
- There are sometimes use cases for including data in a ruby file
  instead of loading it in from a file, say like an SSL certificate, a
  semi-sizeable fixture for a test, or an encrypted string.
- SQL statements in code with wordy interpolations to add quoting or
  whatever
- Developers being showoffs and putting too much stuff on one line.

Right now, the rules force developers to manually wrap lines in all 3
cases. If you ask me, the first 2 happen far more often than silly
developers writing too long lines, so right now, were asking people to
spend their time (still our most precious resource) manually wrapping
text and managing it as it changes. This doesn't sound like spoiling
developers to me, it sounds like useless pedantry. Everyone's editor
supports softwrap, so if you don't like the idea of long lines streching
beyond your viewport, you can configure that in your own environment. It
is inappropriate however to ask that all fellow developers do that
wrapping for you on each of their PRs. Like comon.

@volmer @lucasuyezu @etiennebarrie what do you think? 
