### PR TITLE
Make Rubocop ignore spacing in the db/schema.rb file which is autogen…

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -122,3 +122,7 @@ Style/IfUnlessModifier:
 
 Style/VariableNumber:
   Enabled: false
+
+AllCops:
+  Exclude:
+    - 'db/schema.rb'


### PR DESCRIPTION
…erated but always checked into version control

Recent versions of Rails seem to have started doing this as you migrate. Ok to put this upstream so no one has to think of it ever again? 

@etiennebarrie @volmer 
