### PR TITLE
Disable ExtraSpace cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -20,7 +20,7 @@ Style/TrailingCommaInLiteral:
   Enabled: false
 
 Style/ExtraSpacing:
-  Enabled: false
+  AllowForAlignment: true
 
 Style/SignalException:
   EnforcedStyle: only_raise


### PR DESCRIPTION
I think disabling that cop is a good idea because:
- Our style guide does not mention anything about extra whitespace, other than in cases already covered by other cops, and this cop prevents valid use cases (aligning comments after hash values, for example).
- Extra spaces do not make the code less readable, even in the case of an unintentional extra space.
- Removing spaces to please the bot is an extremely wasteful use of our engineering team's time
- This is a nitpick
- It will make me complain less

@Shopify/policial @etiennebarrie @shawnfrench @mcgain 
