### PR TITLE
New rule: avoid extra whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ developing in Ruby.
 
 * Avoid trailing whitespace.
 
+* Avoid extra whitespace, except for alignment purposes.
+
 * End each file with a newline.
 
 * Don't use block comments:


### PR DESCRIPTION
As discussed in #38, although we do have this rule enabled on RuboCop, it is not mentioned on the style guide. Although we first considered disabling the cop, the rule has its value, and legit usage of extra spacing (for alignment) is permitted:

``` ruby
first:  1,
second: 2,
```
