### PR TITLE
disable SingleLineBlockParams

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -98,3 +98,6 @@ Style/ModuleFunction:
 
 Style/DoubleNegation:
   Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false


### PR DESCRIPTION
Rubocop defaults say we should use single letter block variables. I don't think we should encourage this, it also directly contradicts our styleguide.

> - When using inject with short blocks, name the arguments according to what is
>   being injected, e.g. `|hash, e|` (mnemonic: hash, element)

Also, it says to use `|a,e|` and I don't know what `a` and `e` mean anyway.
