### PR TITLE
Change bad example

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,12 +904,12 @@ developing in Ruby.
   # bad
   url.gsub('http://', 'https://')
   str.gsub('-', '_')
-  str.gsub('case', '')
+  str.gsub(/[aeiou]/, '')
 
   # good
   url.sub('http://', 'https://')
   str.tr('-', '_')
-  str.delete('case')
+  str.delete('aeiou')
   ~~~
 
 * When using heredocs for multi-line strings keep in mind the fact that they


### PR DESCRIPTION
`str.delete('case')` is presented as a faster alternative to `str.gsub('case', '')` but they do different things.  With `str = 'lisp-case-rules'` as in the example, `gsub` returns `lisp--rules` and `delete` returns `lip--rul`: it deletes all `c`, `a`, `s`, and `e` characters instead of all `case` substrings.

@volmer: Is there another example that you'd like to add that captures what you were looking for?

2nd 👀 : @maartenvg
