### PR TITLE
Disable the Style/StructInheritance cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -104,3 +104,6 @@ Style/DoubleNegation:
 
 Style/SingleLineBlockParams:
   Enabled: false
+  
+Style/StructInheritance:
+  Enabled: false


### PR DESCRIPTION
This PR disables the StructInheritance cop.

The cop prevents you from writing `class User < Struct.new(:name)` in favor of `User = Struct.new(:name)`.
Here's a link to the original PR that adds the cop into rubocop: https://github.com/bbatsov/rubocop/pull/1571

As [this comment](https://github.com/bbatsov/rubocop/pull/1571#issuecomment-71946214) points out, there are semantic differences in using what the cops suggest, but moreover, it's just not idiomatic.

The only reason the author of the Cop provides for it is:

```
Extending it introduces a superfluous class level and may also introduce weird errors if the file is required multiple times.
```

The superfluous class level is really just an opinion, and doesn't explain the weird errors.

![image](https://cloud.githubusercontent.com/assets/491230/18643207/0efba27a-7e72-11e6-98d6-1986eab218d3.png)
