### PR TITLE
Discussion: stop telling people to not program defensively

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ developing in Ruby.
 
 * Code in a functional way. Avoid mutation (side effects) when you can.
 
-* Do not program defensively (see
-  [http://www.erlang.se/doc/programming_rules.shtml#HDR11](http://www.erlang.se/doc/programming_rules.shtml#HDR11)).
-
 * Do not mutate arguments unless that is the purpose of the method.
 
 * Do not mess around in / monkeypatch core classes when writing libraries.


### PR DESCRIPTION
"No defensive programming" has been in our Ruby style guide for as long as I remember. I want to evaluate whether we should still push this concept.

Arguments for defensive programming:
- We have hundreds, and in the not too distant future, thousands of people working on the Shopify core code base. Defensive programming can be a tool to help communicate how code should be used, in an asynchronous way.
- It makes assumptions clear, like "this methods should only be called for orders with at exactly one shipping line item". Not testing these assumptions makes for shitty error messages (i.e. `NilClass` exception somewhere deeper down the stack) at best, and potentially more serious bugs at worst.

Defensive programming examples that I have absolutely no problem with:
- `Hash#fetch` over `Hash#[]` (I actually sneaked this into our style guide not too long ago)
- Raising an ArgumentError exception in the `else` clause of a `case` statement. (That's exactly the opposite of the example the Erlang style guide gives)
- Checking for `nil` (especially when this is likely to happen) and raising an exception with a useful error message if you know this will cause problems later.
- Verifying certain assumptions: e.g. `enable_storefront_password(shop)` could start by checking whether the shop actually has the online store channel enabled.

However, I don't want to actively encourage defensive programming either. Stuff we should probably not start doing:
- Check the types of all arguments to a method. This undoes the advantages of duck typing. Let's make sure the name of the variable is descriptive instead.
- Verifying assumptions everywhere. We will end up doing many similar checks down the stack, and pay a big performance penalty. Probably only the entry points of the exposed interface of classes should have checks like that, and not every implementation helper method.

In conclusion, I think it's best to just remove this line.
