### PR TITLE
don't require 0o prefix for octal literals

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -31,6 +31,9 @@ Style/SignalException:
 Style/NumericLiterals:
   Enabled: false
 
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+
 Style/CaseIndentation:
   IndentWhenRelativeTo: end
 


### PR DESCRIPTION
This PR changes the style of octal literals so that we don't require the `0o` prefix for octal literals... leading zero is clear enough

without this you have to...

``` ruby
FileUtils.chmod(0o0600, path)
```

with this PR we'll stick to traditional octal literals...

``` ruby
FileUtils.chmod(0600, path)
```
