### PR TITLE
Disable Style/IfUnlessModifier

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -107,3 +107,6 @@ Style/SingleLineBlockParams:
   
 Style/StructInheritance:
   Enabled: false
+  
+Style/IfUnlessModifier:
+  Enabled: false


### PR DESCRIPTION
This rule has a lot of false positives. I think this one especially is mostly a question of readability and only a human can make this call.
