### PR TITLE
Add Lint/PercentSymbolArray

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -74,6 +74,12 @@ Metrics/PerceivedComplexity:
 Lint/EndAlignment:
   AlignWith: variable
 
+Lint/PercentSymbolArray:
+  Enabled: true
+
+Lint/PercentStringArray:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 


### PR DESCRIPTION
We accidentally used `,` in a `%i` literal which lead to an exception in shopify/Shopify.

This cop catches cases like the following:

``` ruby
%i(max_width, max_height)
%i(:max_width :max_height)
```

In both cases we actually wanted:

``` ruby
%i(max_width max_height)
```

Here's the full description of `Lint/PercentSymbolArray`

> This cop checks for colons and commas in %i, e.g.
> 
> `%i(:foo, :bar)`
> 
> it is more likely that the additional characters are unintended (for
> example, mistranslating an array of literals to percent string notation)
> rather than meant to be part of the resulting symbols.

cc @dylanahsmith 
