### PR TITLE
Disable Style/VariableNumber cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -113,9 +113,12 @@ Style/DoubleNegation:
 
 Style/SingleLineBlockParams:
   Enabled: false
-  
+
 Style/StructInheritance:
   Enabled: false
-  
+
 Style/IfUnlessModifier:
+  Enabled: false
+
+Style/VariableNumber:
   Enabled: false


### PR DESCRIPTION
RuboCop [0.43](https://github.com/bbatsov/rubocop/releases/tag/v0.43.0) introduces the  [`Style/VariableName`](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/variable_number.rb) cop, which allows us to restrict how variables should be named when combined with numbers. We don't have a rule specific for that in the Style Guide, so I am disabling the cop. However we do mention that vars should be named using `snake_case`, so maybe we want to enforce it in names with numbers as well? Like `post_2` instead of `post2`?
