### PR TITLE
Disable Metrics/BlockLength

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -64,6 +64,9 @@ Metrics/ModuleLength:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: false


### PR DESCRIPTION
RuboCop [0.44](https://github.com/bbatsov/rubocop/releases/tag/v0.44.0) is out and it introduces [`Metrics/BlockLength`](https://github.com/bbatsov/rubocop/commit/96f308b4f5601f4642fadc5c5e2826d90df0c0f5), which allows us to restrict low long a block can be. Since we don't have a rule for block length let's disable it.
