### PR TITLE
Allow if statements inside else statements

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -129,6 +129,9 @@ Style/VariableNumber:
 Style/Lambda:
   Enabled: false
 
+Style/IfInsideElse:
+  Enabled: false
+
 AllCops:
   Exclude:
     - 'db/schema.rb'


### PR DESCRIPTION
This PR disabled the IfInsideElse cop

A few times policial has complained to me about having a nested `if` statement inside of an `else` statement, and to fix it I have to force my code to be much less readable. Here's an example

```
if @event.reference_type = "Order"
  if @event.system_generated?
    <do_something>
  else
    <do_something>
  end
elsif @event.reference_type = "DraftOrder"
  if @event.system_generated?
    <do_something>
  else
    <do_something>
  end
else
  if @event.system_generated?
    <do_something>
  else
    <do_something>
  end
end
```
The reasoning for having my if statement inside of an else statement is that my top-level if statements are checking for the `@event.reference_type` not `@event.system_generated?`. By replacing the `else` with an `elsif` the if statement becomes confusing as seen below


```
if @event.reference_type = "Order"
  if @event.system_generated?
    <do_something>
  else
    <do_something>
  end
elsif @event.reference_type = "DraftOrder"
  if @event.system_generated?
    <do_something>
  else
    <do_something>
  end
elsif @event.system_generated?
  <do_something>
else
  <do_something>
end
```