### PR TITLE
Disable NumericPredicate

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -34,6 +34,9 @@ Style/NumericLiterals:
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
 
+Style/NumericPredicate:
+  Enabled: false
+
 Style/CaseIndentation:
   IndentWhenRelativeTo: end
 


### PR DESCRIPTION
This tells you to write `foo.zero?` instead of `foo == 0`, easily leading to weird inconsistent code like `if foo.zero? || foo == 2`.