### PR TITLE
Line Length: ignore test descriptions

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -509,6 +509,8 @@ Metrics/LineLength:
   - http
   - https
   IgnoreCopDirectives: false
+  IgnoredPatterns:
+  - '\A\s*test\s.*(do|->)\Z'
 
 Metrics/ParameterLists:
   Max: 5


### PR DESCRIPTION
Sets the new `IgnoredPatterns` config option to ignore lines that are test descriptions in Ruby or JavaScript. This option will be skipped by any versions of Rubocop < 0.46.

See https://github.com/Shopify/ruby-style-guide/pull/35 for background on this.

/cc @volmer @airhorns @camilo 

If we like this change, I'll do a PR on Shopify to re-enabled `Metrics/LineLength` and use Rubocop 0.46 and bump to this config.

Open to any improvements/suggestions on the regexp. Maybe split it out and just have 2 of them for each language?