### PR TITLE
Disable Performance/TimesMap

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1112,9 +1112,6 @@ Performance/StartWith:
 Performance/StringReplacement:
   Enabled: true
 
-Performance/TimesMap:
-  Enabled: true
-
 Rails/Delegate:
   Enabled: true
 


### PR DESCRIPTION
They are not exactly [equivalent](https://github.com/bbatsov/rubocop/pull/2583)

Also the readability of the Array.new style is debatable.

@volmer @etiennebarrie @mac-adam-chaieb 