### PR TITLE
Add ruby 2.3 to Target Ruby Version

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
   - 'db/schema.rb'
   DisabledByDefault: true
+  TargetRubyVersion: 2.3
 
 Style/AccessModifierIndentation:
   EnforcedStyle: indent


### PR DESCRIPTION
As we're running on 2.3 now, [Policial tells us](https://policial.shopify.io/Shopify/shopify/builds/117611) to update rubocop's yml file.