### PR TITLE
[Breaking change] Make config compatible with RuboCop 0.47

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -80,7 +80,7 @@ Style/BracesAroundHashParameters:
   - context_dependent
 
 Style/CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
   SupportedStyles:
   - case
   - end
@@ -398,7 +398,7 @@ Style/StringLiteralsInInterpolation:
 
 Style/SpaceAroundBlockParameters:
   EnforcedStyleInsidePipes: no_space
-  SupportedStyles:
+  SupportedStylesInsidePipes:
   - space
   - no_space
 
@@ -517,22 +517,22 @@ Metrics/ParameterLists:
   CountKeywordArgs: false
 
 Lint/BlockAlignment:
-  AlignWith: either
-  SupportedStyles:
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
   - either
   - start_of_block
   - start_of_line
 
 Lint/EndAlignment:
-  AlignWith: variable
-  SupportedStyles:
+  EnforcedStyleAlignWith: variable
+  SupportedStylesAlignWith:
   - keyword
   - variable
   - start_of_line
 
 Lint/DefEndAlignment:
-  AlignWith: start_of_line
-  SupportedStyles:
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
   - start_of_line
   - def
 
@@ -626,8 +626,8 @@ Rails/TimeZone:
   - flexible
 
 Rails/UniqBeforePluck:
-  EnforcedMode: conservative
-  SupportedModes:
+  EnforcedStyle: conservative
+  SupportedStyles:
   - conservative
   - aggressive
 
@@ -749,7 +749,7 @@ Style/LeadingCommentSpace:
 Style/LineEndConcatenation:
   Enabled: true
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodMissing:
@@ -950,9 +950,6 @@ Lint/EndInMethod:
 Lint/EnsureReturn:
   Enabled: true
 
-Lint/Eval:
-  Enabled: true
-
 Lint/FloatOutOfRange:
   Enabled: true
 
@@ -1127,6 +1124,9 @@ Rails/OutputSafety:
   Enabled: true
 
 Rails/PluralizationGrammar:
+  Enabled: true
+
+Security/Eval:
   Enabled: true
 
 Security/JSONLoad:


### PR DESCRIPTION
Our current config does not work with RuboCop 0.47 and up because unfortunately RuboCop introduced a breaking change in https://github.com/bbatsov/rubocop/pull/3765

Sadly this commit will break all configs that inherit from our `rubocop.yml` that are still run using RuboCop 0.46 or older.