### PR TITLE
Enable Style/FrozenStringLiteralComment

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -189,6 +189,13 @@ Style/FormatString:
   - sprintf
   - percent
 
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: when_needed
+  SupportedStyles:
+    - when_needed
+    - always
+    - never
+
 Style/GlobalVars:
   AllowedVariables: []
 


### PR DESCRIPTION
This PR enables `Style/FrozenStringLiteralComment` to enforce the presence of the `frozen_string_literal: true` comment when `TargetRubyVersion` is `2.3` and up.

I don't feel the need to change the content of the Style Guide itself because it already mentions to avoid mutation in general.

Shopify Core already has this cop enabled (see https://github.com/Shopify/shopify/pull/99131) as well.