### PR TITLE
Add extra details to Style/FrozenStringLiteralComment

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -190,6 +190,10 @@ Style/FormatString:
   - percent
 
 Style/FrozenStringLiteralComment:
+  Details: >-
+    Add `# frozen_string_literal: true` to the top of the file. Frozen string
+    literals will become the default in a future Ruby version, and we want to
+    make sure we're ready.
   EnforcedStyle: when_needed
   SupportedStyles:
     - when_needed


### PR DESCRIPTION
RuboCop can append extra info to messages, and [now Policial also supports it](https://github.com/volmer/policial/commit/abc761388948299e5f329ec8bfc06f46d8d17473). It could be helpful to explain details about a violation or ways to fix it. This PR start by adding details to `Style/FrozenStringLiteralComment`.

Details can be seen in RuboCop's output using `rubocop -E`. The output will be "Missing frozen string literal comment. Add # frozen_string_literal: true to the top of the file"

On Policial:

![image](https://cloud.githubusercontent.com/assets/301187/22573602/c066fd1e-e977-11e6-845d-9130e522a97b.png)
