### PR TITLE
Ignore all test names length

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -517,7 +517,7 @@ Metrics/LineLength:
   - https
   IgnoreCopDirectives: false
   IgnoredPatterns:
-  - '\A\s*test\s.*(do|->)\Z'
+  - '\A\s*test(_\w+)?\s.*(do|->)(\s|\Z)'
 
 Metrics/ParameterLists:
   Max: 5


### PR DESCRIPTION
When testing interface concerns, we like to write tests like

```ruby
test_each_interface_implementer 'some test description' do |interface_obj|
```

Like all tests, some of these names will exceed 120 chars. This change allows them in rubocop. 