### PR TITLE
Layout/IndentHeredoc -> Style/IndentHeredoc

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -915,7 +915,7 @@ Style/WhileUntilDo:
 Style/ZeroLengthPredicate:
   Enabled: true
 
-Layout/IndentHeredoc:
+Style/IndentHeredoc:
   EnforcedStyle: squiggly
 
 Lint/AmbiguousOperator:


### PR DESCRIPTION
When Ive run rubocop lately I've been getting the following error.
```
Layout/IndentHeredoc has the wrong namespace - should be Style
```