### PR TITLE
Do not enforce delegation.

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1119,9 +1119,6 @@ Performance/StartWith:
 Performance/StringReplacement:
   Enabled: true
 
-Rails/Delegate:
-  Enabled: true
-
 Rails/DelegateAllowBlank:
   Enabled: true
 


### PR DESCRIPTION
I don't think this rule can be automatically enforced because of case like this where delegation is pretty silly.

```
def to_s
  to_h.to_s
end
```
should be rewritten to
```
delegate(:to_s, to: :to_h)
```
which is worse (or maybe equally bad?).