### PR TITLE
Remove rule about omiting parentheses for DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ developing in Ruby.
 
 * Do not use `unless` with `else`. Rewrite these with the positive case first.
 
+* Omit parentheses around parameters for single-line methods that are part
+  of an internal DSL (e.g. Rake, Rails, RSpec, etc., usually methods called
+  in the class definition), methods that have "keyword" status in Ruby
+  (e.g. `attr_reader`, `puts`) and attribute access methods. Use parentheses for
+  multiline method invocations. Also use parentheses around the arguments of
+  all other method invocations.
+
 * Use class methods instead of a rails scope with a multi-line lambda
 
   ~~~ ruby


### PR DESCRIPTION
I propose we remove the rule about omitting parens for DSLs. I argue that it's meant to be broken:

1) It means people have to know the context of what is an internal DSL. I think the rule is pretty vague, especially for newcomers. What constitutes an internal DSL, and what's a normal method call?
2) It doesn't scale well to long invocation (I guess that's probably another topic in itself!)
3) It forces people to use other syntax to get around it

    ```ruby
    delegate \
      :billable?,
      :chargeable_through_api?,
      :chargeable_for_themes?,
      :needs_billing_details?,
      to: :base_plan
    ```
4) It prevents us from using trailing commas

    ```diff
    attr_accessor(
      :name,
      :foo,
    + :bar,
    )
    ```

    ```diff
    attr_accessor \
      :name,
    -  :foo
    + :foo,
    + :bar
    ```


5) And finally, we already break it all the time (and it makes me happy) 