### PR TITLE
Remove Lint/InvalidCharacterLiteral since it is obsolete

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -977,10 +977,6 @@ Lint/IneffectiveAccessModifier:
   Description: Checks for attempts to use `private` or `protected` to set the visibility
     of a class method, which does not work.
 
-Lint/InvalidCharacterLiteral:
-  Description: Checks for invalid character literals with a non-escaped whitespace
-    character.
-
 Lint/LiteralInCondition:
   Enabled: true
 


### PR DESCRIPTION
See https://github.com/bbatsov/rubocop/pull/4746/files

This was removed on Sep 24. Throws errors with latest rubocop.