### PR TITLE
Remove contradictory instruction regarding singleton method definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,8 +1099,6 @@ developing in Ruby.
 
 * Avoid long parameter lists.
 
-* Use `def self.method` to define singleton methods.
-
 * Avoid needless metaprogramming.
 
 * Never start a method with `get_`.


### PR DESCRIPTION
@kmcphillips @volmer @dylanahsmith 

Followup to #29 

The styleguide currently has two contradictory instructions regarding the best way to define singleton / class methods:

`* Use a class << self block over def self. when defining class methods`
`* Use def self.method to define singleton methods.`

This diff simply removes the second instruction.

Relevant conversation from `#ruby-style-guide`:

> @dylan.smith: I think the reason for the former one was because we wanted to avoid `def self.` defined class methods after `private` or `protected`, but there is actually a cop for that http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Lint/IneffectiveAccessModifier

> @katniss.everdeen: I don’t think that contradiction is intentional. I think we just forgot to remove that line when we shipped https://github.com/Shopify/ruby-style-guide/pull/29
cc @kmcphillips