### PR TITLE
Remove SpaceInsideBrackets in favor of SpaceInsideArrayLiteralBrackets

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -420,6 +420,7 @@ Layout/SpaceAroundOperators:
 
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: space
   SupportedStyles:
   - space
   - no_space


### PR DESCRIPTION
SpaceInsideBrackets was remove in https://github.com/bbatsov/rubocop/pull/5149