### PR TITLE
Exclude vertical alignment from whitespacing rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ developing in Ruby.
 
 * Avoid trailing whitespace.
 
-* Avoid extra whitespace, except for alignment purposes.
+* Avoid extra whitespace, except for indentation purposes.
 
 * End each file with a newline.
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -159,7 +159,7 @@ Layout/EmptyLinesAroundModuleBody:
   - no_empty_lines
 
 Layout/ExtraSpacing:
-  AllowForAlignment: true
+  AllowForAlignment: false
   ForceEqualSignAlignment: false
 
 Naming/FileName:


### PR DESCRIPTION
Following a discussion in [#ruby-style-guide](https://shopify.slack.com/messages/C0DRQ0HEJ/) on vertical alignment, the consensus was that it should be removed from the language of our style guide.

Participants were @rafaelfranca @etiennebarrie @lugray @thegedge @volmer 

The key arguments for the change were:
- Vertical align decrease maintainability since you have to change surrounding lines if you new line is going to miss align with them ([Example](https://github.com/rails/rails/commit/4a835aa3236eedb135ccf8b59ed3c03e040b8b01#diff-5762f42ce6ab7104d2d361e20112979a
))
- Long elements force things so far apart, making it harder to read.
- Sometime poor variable names are used to avoid re-aligning the surrounding lines

## Existing cops supporting this change
### Layout/AlignHash
config: https://github.com/Shopify/ruby-style-guide/blob/master/rubocop.yml#L20
doc: https://rubocop.readthedocs.io/en/latest/cops_layout/#examples_2

### Layout/AlignParameters
config: https://github.com/Shopify/ruby-style-guide/blob/master/rubocop.yml#L30
doc: https://rubocop.readthedocs.io/en/latest/cops_layout/#enforcedstyle-with_fixed_indentation





