### PR TITLE
remove cop for hash each methods

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1080,9 +1080,6 @@ Performance/FixedSize:
 Performance/FlatMap:
   EnabledForFlattenWithoutParams: false
 
-Performance/HashEachMethods:
-  Enabled: true
-
 Performance/LstripRstrip:
   Enabled: true
 


### PR DESCRIPTION
We get false positives from `Performance/HashEachMethods`. We have our own thing that exposes `.values` (it's an enum), and if we iterate over those values, the rule triggers because it thinks our enum is a hash. I'd argue that the rule doesn't make a lot of sense. It seems to suggest a perf optimization that for most cases of iterating over a hash should not be necessary, and it matches in a really dumb way (apparently, all things that have a `values` method are a hash). 

So I'd like to deactivate that rule.

example build: https://policial.shopify.io/Shopify/shopify/builds/412372

@etiennebarrie commented in #ruby-style-guide that it's not part of our style guide anyway 