### PR TITLE
Exclude node_modules from RuboCop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
   - 'db/schema.rb'
+  - 'node_modules/**/*'
   DisabledByDefault: true
 
 Layout/AccessModifierIndentation:


### PR DESCRIPTION
I’ve added a rule to exclude the `node_modules` folder from RuboCop. Previously, it was finding all kinds of style violations in Rails apps using Yarn and Webpacker.