### PR TITLE
Ignore line length restriction for remote_test method

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -518,7 +518,7 @@ Metrics/LineLength:
   - https
   IgnoreCopDirectives: false
   IgnoredPatterns:
-  - '\A\s*test(_\w+)?\s.*(do|->)(\s|\Z)'
+  - '\A\s*(remote_)?test(_\w+)?\s.*(do|->)(\s|\Z)'
 
 Metrics/ParameterLists:
   Max: 5


### PR DESCRIPTION
We did this for our `test` macro back in https://github.com/Shopify/ruby-style-guide/pull/57, this simply provides the same exception for the `remote_test` helper, which is used throughout Shopify Core and a few other applications.