### PR TITLE
Add new rules for 0.53.0

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -368,6 +368,10 @@ Style/RegexpLiteral:
 
 Style/SafeNavigation:
   ConvertCodeThatCanStartToReturnNil: false
+  Enabled: true
+
+Lint/SafeNavigationChain:
+  Enabled: true
 
 Style/Semicolon:
   AllowAsExpressionSeparator: false
@@ -524,21 +528,21 @@ Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: false
 
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   EnforcedStyleAlignWith: either
   SupportedStylesAlignWith:
   - either
   - start_of_block
   - start_of_line
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
   SupportedStylesAlignWith:
   - keyword
   - variable
   - start_of_line
 
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   EnforcedStyleAlignWith: start_of_line
   SupportedStylesAlignWith:
   - start_of_line
@@ -928,7 +932,7 @@ Lint/AmbiguousRegexpLiteral:
 Lint/CircularArgumentReference:
   Enabled: true
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Enabled: true
 
 Lint/Debugger:


### PR DESCRIPTION
I had a quick look at new rules: https://github.com/bbatsov/rubocop/commit/b65c4d51fea57e458b85d26364da6a4fc0ef2eea?short_path=b07e4fb#diff-b07e4fbd476a6c0ae713028c94544151
I enabled lint rules that prevent runtime errors and auto-correctible rules.

* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/unneeded_cop_enable_directive.rb#L10-L11
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/big_decimal_new.rb#L6-L8
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_body_on_class.rb#L6
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_body_on_module.rb#L6
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb#L24-L32
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb#L24-L32
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/layout/space_inside_reference_brackets.rb#L6-L7
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/module_function.rb#L6-L7
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/ordered_magic_comments.rb#L7-L8
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/safe_navigation_chain.rb#L6-L10
* https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/security/open.rb#L6-L11

Most of them have auto-correction so the cost of enabling them should be close to zero, and those that do have auto-correction do not change the runtime so they are safe to apply.

closes #55