### PR TITLE
Change CommandLiteral rule to prefer "%x" instead of "`"

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -100,7 +100,7 @@ Style/ClassCheck:
   - kind_of?
 
 Style/CommandLiteral:
-  EnforcedStyle: backticks
+  EnforcedStyle: percent_x
   SupportedStyles:
   - backticks
   - percent_x


### PR DESCRIPTION
Matz wants to deprecate "\`" so it is better to use %x in our codebase so we don't have to change everything to "\`" and later back to "%x"

https://bugs.ruby-lang.org/issues/14385