### PR TITLE
Add Time best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,11 @@ developing in Ruby.
 * Prefer `map` over `collect`, `find` over `detect`, `select` over `find_all`,
   `size` over `length`.
 
+* Prefer `Time` over `DateTime` since it supports proper time zones instead of
+  UTC offsets. [More info](https://gist.github.com/pixeltrix/e2298822dd89d854444b).
+  
+* Prefer `Time.iso8601(foo)` instead of `Time.parse(foo)` when expecting ISO8601 formatted
+  time strings like `"2018-03-20T11:16:39-04:00"`.
 
 ## Naming
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -698,6 +698,9 @@ Layout/CommentIndentation:
 Naming/ConstantName:
   Enabled: true
 
+Style/DateTime:
+  Enabled: true
+
 Style/DefWithParentheses:
   Enabled: true
 


### PR DESCRIPTION
Time<>DateTime came from this Slack convo: https://shopify.slack.com/archives/C08CPK9JB/p1521215360000036 cc @rafaelfranca 

Parsing: the preferred form will raise on invalid input while `Time.parse` will apply some kind of heuristic which may change over time. It's a bit faster too.