### PR TITLE
Enable Performance/RegexpMatch cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1105,6 +1105,9 @@ Performance/RedundantMatch:
 Performance/RedundantSortBy:
   Enabled: true
 
+Performance/RegexpMatch:
+  Enabled: true
+
 Performance/ReverseEach:
   Enabled: true
 


### PR DESCRIPTION
It's 2x faster in microbenchmarks according to https://github.com/JuanitoFatas/fast-ruby/blob/master/README.md#regexp-vs-stringmatch-vs-string-vs-stringmatch-code- since it skips creating MatchData objects. 

A more real-life example can be found at https://github.com/ruby/csv/pull/30

It's the next best thing if StartWith/EndWith cops (which are already enabled) don't work for you.

Autocorrectable with: `bin/rubocop --only Performance/RegexpMatch --auto-correct`