### PR TITLE
Add a separate styleguide for CLI apps

### DIFF
--- a/rubocop-cli.yml
+++ b/rubocop-cli.yml
@@ -1,0 +1,52 @@
+inherit_from:
+  - http://shopify.github.io/ruby-style-guide/rubocop.yml
+
+AllCops:
+  # We don't always use bundler to make for a faster boot time.
+  # In this case we vendor a small number of dependencies we absolutely
+  # require. Since they are vendored and 3rd party we do not impose our
+  # styleguide on them but they are still in the repo.
+  Exclude:
+    - 'vendor/**/*'
+
+  # Mac OS High Sierra ships with Ruby 2.3.x
+  # Therefore we target Ruby 2.3
+  TargetRubyVersion: 2.3
+
+# We disable this at entrypoint.
+# Due to CLI apps being invoked via an entry point,
+# we can exclude this from all files
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# This doesn't take into account retrying from an exception. E.g.:
+#   begin
+#     retries ||= 0
+#     do_a_thing
+#   rescue => e
+#     retry if (retries += 1) < 3
+#     handle_error(e)
+#   end
+Lint/HandleExceptions:
+  Enabled: false
+
+# Allow the use of globals which occasionally makes sense in a CLI app
+# As we are not multi-threaded and have a single entry point, this makes it easy to,
+# for example, track process environments to restore at the end of invocation
+Style/GlobalVars:
+  Enabled: false
+
+# Allow readable block formatting in some weird cases
+# Particularly in something like:
+#   Dev::Util.begin do
+#     might_raise_if_costly_prep_not_done()
+#   end.retry_after(ExpectedError) do
+#     costly_prep()
+#   end
+Style/MultilineBlockChain:
+  Enabled: false
+
+# Our extensive use of blocks in our CLI apps means that it is more
+# expessive and easier to read a block var name than a random yield
+Performance/RedundantBlockCall:
+  Enabled: false


### PR DESCRIPTION
The Ruby Style Guide is a great way to maintain consistency between projects.

During our development of internal CLI tools, it became apparent that some of the rules did not make sense for CLI apps.

This adds a separate style guide that selectively disables certain aspects that do not translate as well into CLIs, and adds comments explaining each exclusion.