### PR TITLE
Prefer use of %r{} form for multiline regexp literals

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -359,7 +359,7 @@ Style/RedundantReturn:
   AllowMultipleReturnValues: false
 
 Style/RegexpLiteral:
-  EnforcedStyle: slashes
+  EnforcedStyle: mixed
   SupportedStyles:
   - slashes
   - percent_r


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RegexpLiteral

We have this check entirely disabled in @Shopify/dev-infra's tools, but looking at the docs, it seems like what we actually want is `mixed` enforcement:

`/abc/` (default to requiring slashes, as we already do)
`%r{a/b}` (require %r when slashes present, as we already do)

```
%r{
  a
  _
  b
}x
```

require %r for multiline. This part is different: we require slashes for this form currently.