### PR TITLE
Fix for Rubocop 0.56

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -767,7 +767,10 @@ Style/LineEndConcatenation:
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
-Style/MethodMissing:
+Style/MethodMissingSuper:
+  Enabled: true
+
+Style/MissingRespondToMissing:
   Enabled: true
 
 Style/MultilineBlockChain:


### PR DESCRIPTION
Fixes `rubocop.yml` for version 0.56 due to the following change:
```
Split Style/MethodMissing into two cops, Style/MethodMissingSuper and Style/MissingRespondToMissing.
```

### Side effects:
`Style/MethodMissing` is no longer checked for versions 0.55 or lower