### PR TITLE
Add recommended rubocop version

### DIFF
--- a/rubocop-cli.yml
+++ b/rubocop-cli.yml
@@ -1,3 +1,5 @@
+# Recommended rubocop version: ~> 0.56.0
+
 inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,5 @@
+# Recommended rubocop version: ~> 0.56.0
+
 AllCops:
   Exclude:
   - 'db/schema.rb'


### PR DESCRIPTION
Regardless of the `.rubocop.yml` settings, there can be discrepencies between a project's `dev style` and [policial](https://github.com/Shopify/policial).

Advertise a recommended rubocop version, also matching the latest revision the `.rubocop.yml` was updated for.