### PR TITLE
Disable ConstantInConstantInclude for now

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1178,3 +1178,6 @@ Style/ModuleFunction:
 
 Lint/OrderedMagicComments:
   Enabled: true
+
+Sorbet/ConstantInConstantInclude:
+  Enabled: false


### PR DESCRIPTION
I don't know how this cop ends up being run by default, especially since we have https://github.com/Shopify/ruby-style-guide/blob/master/rubocop.yml#L6, but it's currently running on Policial on all projects. The Cop isn't ready yet and produce false positives.