### PR TITLE
Allow chaining on multiline blocks

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -775,9 +775,6 @@ Style/MethodMissingSuper:
 Style/MissingRespondToMissing:
   Enabled: true
 
-Style/MultilineBlockChain:
-  Enabled: true
-
 Layout/MultilineBlockLayout:
   Enabled: true
 


### PR DESCRIPTION
With the addition of the `Results::Result` type as part of the componentization toolkit, there are occasional situations when it is useful to chain on the end of a multiline block, as part of a continuation of a `#map`

This need motivated the same change in [another Shopify repo.
](https://github.com/Shopify/waffle-cone/blob/5934f582961a6612c7fee0296c7e230bf519d801/.rubocop.yml#L48-L49).