### PR TITLE
Enable Rails/InverseOf cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1138,6 +1138,9 @@ Rails/HttpPositionalArguments:
   - spec/**/*
   - test/**/*
 
+Rails/InverseOf:
+  Enabled: true
+
 Rails/OutputSafety:
   Enabled: true
 


### PR DESCRIPTION
> This cop looks for has_(one|many) and belongs_to associations where Active Record can't automatically determine the inverse association because of a scope or the [options](https://github.com/rails/rails/blob/c7bc79b6918e3cd0fe7ce387e52c9b4c64ef4421/activerecord/lib/active_record/reflection.rb#L574) used.

https://rubocop.readthedocs.io/en/latest/cops_rails/#railsinverseof originated from this change: https://github.com/Shopify/shopify/pull/129174

For core we'll need to change the default configuration to work with components directory structure: https://github.com/rubocop-hq/rubocop/blob/abb655a0f0ecce626d4009a5fcf41e077a445811/config/default.yml#L2385-L2386

Before I start fixing components, I wanted to check here we think it's a good idea to turn it on 😄 