### PR TITLE
Add Style/MethodCallWithArgsParentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,30 @@ developing in Ruby.
 * Use parentheses around the arguments of method invocations. Omit parentheses
   when not providing arguments. Also omit parentheses when the invocation is
   single-line and the method:
-  - is part of an internal DSL (e.g. Rake, Rails, RSpec, etc., usually methods
-    called in the class definition)
-  - has "keyword" status in Ruby (e.g. `attr_reader`, `puts`)
-  - is an attribute accessor
+  - is a class method call with inplict receiver
+
+  ~~~ ruby
+  # bad
+  class User
+    include(Bar)
+    has_many(:posts)
+  end
+
+  # good
+  class User
+    include Bar
+    has_many :posts
+    SomeClass.some_method(:foo)
+  end
+  ~~~
+
+  - is one of the following methods:
+    * `require`
+    * `require_relative`
+    * `require_dependency`
+    * `yield`
+    * `raise`
+    * `puts`
 
 * Use class methods instead of a rails scope with a multi-line lambda
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -258,6 +258,19 @@ Style/Next:
 Style/NonNilCheck:
   IncludeSemanticChanges: false
 
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  IgnoreMacros: true
+  IgnoredMethods:
+  - require
+  - require_relative
+  - require_dependency
+  - yield
+  - raise
+  - puts
+  Exclude:
+  - Gemfile
+
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses
   SupportedStyles:


### PR DESCRIPTION
The main motivation is of course consistency. Now instead of deciding if the method should put parentheses or not, we always put them, the exceptions are on class macros and some ignored methods.

Given the Gemfile is a heavy user of DSLs it is completely excluded.

This change cop also brings one advantage in terms of code safety that block precedence now is easier to understand since you can use parentheses to define it. That brings to one problem that excluding class macros causes, they are also suppressible to block precedence problems.

See https://github.com/Shopify/shopify/pull/179227 for corrected code.