### PR TITLE
Add ignored methods to MethodCallWithArgsParentheses for Rspec

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -268,6 +268,9 @@ Style/MethodCallWithArgsParentheses:
   - yield
   - raise
   - puts
+  - describe
+  - to
+  - to_not
   Exclude:
   - Gemfile
 


### PR DESCRIPTION
The `MethodCallWithArgsParentheses` cop was enabled in https://github.com/Shopify/ruby-style-guide/pull/99

This PR adds additional ignored methods to support rspec cases so we can avoid parens hell when using Rspec:

`Rspec.describe`
`expect().to eq()`
`expect().to_not eq()`

I'm not sure if this provides complete coverage for rspec, I'm just getting this started.