### PR TITLE
RFC: Make this into a gem for improved rubocop usage?

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/ruby-style-guide.gemspec
+++ b/ruby-style-guide.gemspec
@@ -1,0 +1,27 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name          = "ruby-style-guide"
+  spec.version       = '0.0.1'
+  spec.authors       = ["Shawn French"]
+  spec.email         = ["shawn.french@shopify.com"]
+
+  spec.summary       = 'Shopify-specific ruby styleguide codified into a RuboCop config'
+  spec.homepage      = 'https://github.com/Shopify/ruby-style-guide'
+  spec.license       = "MIT"
+
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
+  end
+
+  spec.files = ['README.md', 'LICENSE.txt', 'rubocop.yml', 'rubocop-cli.yml']
+
+  spec.add_dependency 'rubocop', '~> 0.53'
+  spec.add_development_dependency "bundler", "~> 1.16"
+end


### PR DESCRIPTION
Making `ruby-style-guide` into a gem would improve our development workflow with rubocop at Shopify.

### How?
Once the dependency is added:
`gem 'ruby-style-guide', '~> 0.0.1', source: PACKAGE_CLOUD`

the Shopify project can use the `inherit_gem` config directive (documented [here](https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#inheriting-configuration-from-a-dependency-gem)) to inherit from the version-controlled gem's YAML instead of the gihub.io file.

Instead of:
```
inherit_from:
  - https://shopify.github.io/ruby-style-guide/rubocop.yml
```
we'd use:
```
inherit_gem:
  ruby-style-guide: rubocop.yml
```

### Why?
The benefits are the same as any other gem - but the biggest win is projects can decide when to change versions and do so conveniently.

We would no longer need to commit the local cache file `.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml` and keep it up to date manually.

We could also formalize the associated rubocop version to our config by adding a gem dependency so that breaking changes to the YAML are reflected in a hard dependency.
eg. `spec.add_dependency 'rubocop', '~> 0.53'`

### Why not?
Dev galaxy or git submodules could be used for referencing this repo instead of a gem - and this isn't exactly pressing so maybe we just wait?

### TODO
- I just did the very basics of `bundle gem ...` and we'd need to do stuff for package cloud at the very least

### Thoughts?