### PR TITLE
Exclude Gemfile listed in the regular `gemfiles` dir:

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -270,6 +270,8 @@ Style/MethodCallWithArgsParentheses:
   - puts
   Exclude:
   - Gemfile
+  - 'gemfiles/*'
+  - '*.gemspec'
 
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses


### PR DESCRIPTION
- Most of our internal gems test multiple version of a dependency,
  each Gemfiles are usually (always almost the case) in the `gemfiles`
  directory.

  Also whitelist `.gemspec` files