### PR TITLE
Allow unused keyword arguments

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -573,7 +573,7 @@ Lint/UnusedBlockArgument:
   AllowUnusedKeywordArguments: false
 
 Lint/UnusedMethodArgument:
-  AllowUnusedKeywordArguments: false
+  AllowUnusedKeywordArguments: true
   IgnoreEmptyMethods: true
 
 Performance/RedundantMerge:


### PR DESCRIPTION
The `Lint/UnusedMethodArgument` sometimes gets in the way of
abstractions. It makes it harder to specify an interface which objects
must repond to, as it makes it harder for implementations to ignore the
parameters.

Take for example:

```ruby
module EmailDelivery
  interface!

  sig { params(email: Email, recipient: EmailAddress) }.void
  def send(email, recipient:)
  end
end

class NoopEmailDelivery
  include(EmailDelivery)

  sig { params(email: Email, recipient: EmailAddress) }.void
  def send(email, recipient:)
    log("We sent an email to #{recipient}")
  end
end
```

This implementation would be invalid because `email` cannot be used as a
parameter name.

Disallowing unused positional arguments is easy, because Rubocop accepts
them being prefixed with an underscore (`_email`). As such, they preserve
the informative value, but still signal that they will be unused.

Disallowing unused keyword arguments is much trickier. One cannot prefix
them with an underscore; it would change the API to the method.

Rubocop suggests accepting `*`, but this changes the contract of the
method: `def send(email, recipient:)` is not the same thing as
`def send(email, *)`.

I think we should relax this cop to allow unused name parameters.

There's an obvious downside to doing it: we aren't notified of unused
named parameters anymore. I think the tradeoff between less friction to
API design and potential dead code is worth it in this case.