### PR TITLE
Ignore the `test` method from parentheses cop

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ developing in Ruby.
     * `yield`
     * `raise`
     * `puts`
+    * `test`
 
 * Use class methods instead of a rails scope with a multi-line lambda
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -268,6 +268,7 @@ Style/MethodCallWithArgsParentheses:
   - yield
   - raise
   - puts
+  - test
   Exclude:
   - Gemfile
 


### PR DESCRIPTION
I'm quite reluctant to do this, but here's the proposition: not require parens for `test` method arguments.

My rationale is only that I'm afraid that having to write `test("the thing works")` will cause more friction than necessary, even though I'd be in favour of writing it that way.

The collision risk also has to be considered, but there are 6 `test` methods in Shopify/shopify, 5 of which return boolean, and none of them take parameters. 

I'm really on the fence, and I'd like to know what y'all think before I start applying corrections to Shopify/shopify.