### PR TITLE
Start enforcing parens on macros with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,31 +248,54 @@ developing in Ruby.
 
 * Use parentheses around the arguments of method invocations. Omit parentheses
   when not providing arguments. Also omit parentheses when the invocation is
-  single-line and the method:
-  - is a class method call with inplict receiver
-
-  ~~~ ruby
-  # bad
-  class User
-    include(Bar)
-    has_many(:posts)
-  end
-
-  # good
-  class User
-    include Bar
-    has_many :posts
-    SomeClass.some_method(:foo)
-  end
-  ~~~
-
-  - is one of the following methods:
+  single-line and the method is one of:
     * `require`
     * `require_relative`
     * `require_dependency`
     * `yield`
     * `raise`
     * `puts`
+
+  ~~~ ruby
+  # bad
+  require("checkout")
+
+  class User
+    include Bar
+    has_many :posts
+  end
+
+  # bad
+  yield [
+    1,
+    2,
+  ]
+
+  # bad
+  raise StandardError,
+    "don't do that"
+
+  # good
+  require "checkout"
+
+  class User
+    include(Bar)
+    has_many(:posts)
+
+    puts "This is user"
+  end
+
+  # good
+  yield([
+    1,
+    2,
+  ])
+  raise(
+    StandardError,
+    "don't do that"
+  )
+  ~~~
+
 
 * Use class methods instead of a rails scope with a multi-line lambda
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -260,7 +260,7 @@ Style/NonNilCheck:
 
 Style/MethodCallWithArgsParentheses:
   Enabled: true
-  IgnoreMacros: true
+  IgnoreMacros: false
   IgnoredMethods:
   - require
   - require_relative
@@ -268,6 +268,7 @@ Style/MethodCallWithArgsParentheses:
   - yield
   - raise
   - puts
+  - test
   Exclude:
   - Gemfile
 


### PR DESCRIPTION
This is a follow up on #99, more specifically to this [comment](https://github.com/Shopify/ruby-style-guide/pull/99#discussion_r234640657).

This PR removes the `IgnoreMacros: true` for the `Style/MethodCallWithArgsParentheses` cop, effectively meaning that we'll start asking devs to use parentheses around method calls.

Before this PR goes out, we **need** to:
- [ ] ensure communication that this change is coming down
- [ ] merge https://github.com/Shopify/shopify/pull/183789 on Core
- [ ] encourage devs to apply the same diff to their own projects beforehand