### PR TITLE
Move FlipFlop cop to the Lint department

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -754,7 +754,7 @@ Style/EvenOdd:
 Layout/InitialIndentation:
   Enabled: true
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Enabled: true
 
 Style/IfInsideElse:


### PR DESCRIPTION
To reflect changes made in RuboCop 0.63.1. 

https://github.com/rubocop-hq/rubocop/pull/6636