### PR TITLE
Try and avoid any_instance in mocha expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1138,6 +1138,21 @@ developing in Ruby.
   end
   ~~~
 
+* When using expectations, avoid using `any_instance`. If your test requires
+  `any_instance` in order to pass, consider refactoring the code in question,
+  the test, or both to be more explicit about it's dependencies.
+
+  ~~~ ruby
+  # bad
+  User.any_instance.expects(:valid?)
+  UserValidator.validate_user(1)
+
+  # good
+  user = User.new
+  user.expects(:valid?)
+  UserValidator.validate_user(user)
+  ~~~
+
 ## The rest
 
 * Avoid long methods.


### PR DESCRIPTION
This PR is opened as mostly as a conversation starter. 

I've been working on refactoring some tests in order to prevent stubbing of non-existent methods in Mocha in `shopify/shopify`. One of the things I've noticed is that a lot of the sites that are problematic also use `any_instance`.

A quick `git grep -r '.any_instance' | wc -l` in `shopify/shopify` shows we have `10070` uses of `any_instance` in the codebase.

In my experience this could be considered a code smell. `any_instance` has it's uses, but in a lot of cases can indicate code that is too complex, doesn't manage it's dependancies in an obvious manner, and can result in bugs due to the wide-reaching effects of stubbing a method on any (and every) instance of a class.

I'd like to propose that we make an effort to avoid using `any_instance` and instead make an effort to refactor our code, our tests, or both, in order to make them easier to test and the intention clearer.