### PR TITLE
Remove Performance/RedundantBlockCall cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1113,9 +1113,6 @@ Performance/LstripRstrip:
 Performance/RangeInclude:
   Enabled: true
 
-Performance/RedundantBlockCall:
-  Enabled: true
-
 Performance/RedundantMatch:
   Enabled: true
 


### PR DESCRIPTION
This PR is a proposition to remove the `Performance/RedundantBlockCall` cop.

This cop, along with `Lint/UnusedMethodArgument` conflict with Sorbet.

Take this example:

```ruby
sig { params(block: T.proc.params(i: Integer)).void }
def record_duration(&block)
  block.call(1)
end
```

The first warning will be `Performance/RedundantBlockCall`, and will change the code to 

```ruby
sig { params(block: T.proc.params(i: Integer)).void }
def record_duration(&block)
  yield 1 # block.call -> yield
end
```

The 2nd warning will be `Lint/UnusedMethodArgument` and will change to:

```ruby
sig { params(block: T.proc.params(i: Integer)).void }
def record_duration(&_block) # block -> _block
  yield 1
end
```

Sorbet will now complain that `block` is not defined and `_block` is not annotated, requiring a human to change it to:

```ruby
sig { params(_block: T.proc.params(i: Integer)).void } # block -> _block
def record_duration(&_block)
  yield 1
end
```

Now admittedly this code _works_, but we're losing a lot of the meaning in the process