### PR TITLE
Allow use of the situautionally best delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,11 +1066,9 @@ developing in Ruby.
 * Avoid the use of `%s`. Use `:"some string"` to create a symbol with spaces in
   it.
 
-* Prefer `()` as delimiters for all `%` literals, except `%r`. Since parentheses
-  often appear inside regular expressions in many scenarios a less common
-  character like `{` might be a better choice for a delimiter, depending on the
-  regexp's content.
-
+* Prefer `()` as delimiters for all `%` literals, except, as often occurs in
+  regular expressions, when parentheses appear inside the literal. Use the first
+  of `()`, `{}`, `[]`, `<>` which does not appear inside the literal.
 
 ## Testing
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -332,18 +332,6 @@ Style/NumericLiteralPrefix:
 Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true
 
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%': '()'
-    '%i': '()'
-    '%q': '()'
-    '%Q': '()'
-    '%r': '{}'
-    '%s': '()'
-    '%w': '()'
-    '%W': '()'
-    '%x': '()'
-
 Style/PercentQLiterals:
   EnforcedStyle: lower_case_q
   SupportedStyles:


### PR DESCRIPTION
Rather than enforcing the use of `()` for percent literal delimiters everywhere except for regexes, take the wisdom that made an exception for regexes due to their frequent use of `()` within them, and apply it more broadly to allow the developer to choose a delimiter not present in the literal in all cases.

Motivated by https://github.com/Shopify/dev/pull/2394/files#r259458798