### PR TITLE
Moving FlipFlop under proper namespace

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -745,7 +745,7 @@ Style/EvenOdd:
 Layout/InitialIndentation:
   Enabled: true
 
-Lint/FlipFlop:
+Style/FlipFlop:
   Enabled: true
 
 Style/IfInsideElse:


### PR DESCRIPTION
Before:
```
Lucianos-MacBook-Pro:spy ls$ bin/rubocop
.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml: Lint/FlipFlop has the wrong namespace - should be Style
Warning: unrecognized cop Sorbet found in .rubocop.yml
Inspecting 471 files
.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

471 files inspected, no offenses detected
```

After:
```
Lucianos-MacBook-Pro:spy ls$ bin/rubocop
Warning: unrecognized cop Sorbet found in .rubocop.yml
Inspecting 471 files
.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

471 files inspected, no offenses detected
```