### PR TITLE
Stop enforcing percent array literals

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1013,12 +1013,6 @@ Lint/NonLocalExitFromIterator:
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true
 
-Lint/PercentStringArray:
-  Enabled: false
-
-Lint/PercentSymbolArray:
-  Enabled: false
-
 Lint/RandOne:
   Description: Checks for `rand(1)` calls. Such calls always return `0` and most
     likely a mistake.


### PR DESCRIPTION
**TL; DR: Percent array literals are so complicated they're just stupid. 
Also we make mistake in them in ways it's impossible using `[]`.**

https://github.com/Shopify/shopify/blob/f6d1b6db5e62db31a3c879d6fd945f63c287f350/components/checkouts/web/app/controllers/checkouts/web/checkouts_controller.rb#L977-L980
https://github.com/Shopify/shopify/commit/a01a3177050cf1f36c8eb9cc8a65b16aaab65d9f
https://github.com/Shopify/shopify/commit/4c424c05ee959686c8931b368aae11ffba5fccb2#diff-4d2b3d86fd2cc5bf583bc56842df6b59R97
https://github.com/Shopify/shopify/commit/7a1d74a58754bdfbc1d35a399ec005b25efdc786#diff-ac07168575e49923b6535561a07881f4L5
https://github.com/Shopify/shopify/commit/7c78da4faa2849d4a67b486e66d485bd6a468f45#diff-6440834537bbd5b28ef3ef38707856deR12
https://github.com/Shopify/shopify/commit/d502dc5004d5677d6dd7b83b2ed1bba3bde77b88#diff-2dedb8edd0cfaa40d091c8923caa2988R13

And sometimes we just get false positives in our tooling because they're wholly inadequate:
https://github.com/Shopify/shopify/commit/d22f2da9b2137b82c72e8265521b46f4375d5187#diff-aee6dbbff121d0b6b908b1137e85c577R94

---

This is copied from: https://github.com/Shopify/ruby-style-guide/pull/112#issuecomment-467057315

What would you think of going full steam reverse on the `%` literals, suggesting they not be used instead?

As usual, my argument comes from the standpoint of simplicity. Percent literals inherently add to the complexity of Ruby's syntax, but the good news is that we don't need to use them. 

Why do they add to complexity? First, let's examine non-percent literals.

Barring percent-literals and heredocs, we have two ways of expressing Strings: double, and single quotes. The former supports interpolation and character escaping, the latter does not. 

For strings, we have 2 rules (single quotes, double quotes). Running complexity: 2.

The same thing is true for symbols: we have colon-symbol literal (`:foo`). The colon-symbol literal combines nicely with quote literals, and preserves its rules. 

```ruby
print :'foo\nbar#{1}'
# prints:
#   foo\nbar#{1}

print :"foo\nbar#{1}"
# prints:
#   foo
#   bar1
```

For symbols, we have 2 rules (without quotes, with quotes). Running complexity: 4 (2 + 2).

We also have array literals in the form of `[]`. As for symbols, it combines nicely with all of the other rules (this should come to no surprise if you've done *any PL* for more than a few minutes). You can build an array of symbol, string, or numeric literals just by combining them:

```ruby
[1, 2, 3]
#=> [1, 2, 3]

["a\n#{1}", 'b\n#{2}', "string with a comma,"]
#=> => ["a\n1", "b\\n\#{2}", "string with a comma,"]
```

Arrays have a single rule. Running complexity: 5 (2 + 2 + 1).

Combining behaviour, after all, is how we achieve simplicity (and why OOP and FP exist).

What about percent literals?

String literals are mostly fine. We have `%`, `%Q`, and `%q`. While you have to remember their interpolation and escaping rules, you can get away with them. 

On their own, they'd have a complexity factor of 3, however, we also dictate what _can_ and _cannot_ use `%q` and `%Q` using a few cops. I don't know how many rules there are, but there is _at least_ three, as shown by this example.

```
[Corrected] Style/BarePercentLiterals: Use % instead of %Q.
      %Q(a,b, "c")
      ^^^
[Corrected] Style/PercentQLiterals: Do not use %Q unless interpolation is needed. Use %q.
      %Q(a,b, "c")
      ^^^
[Corrected] Style/UnneededPercentQ: Use %Q only for strings that contain both single quotes and double quotes, or for dynamic strings that contain double quotes.
      %Q(a,b, "c")
      ^^^^^^^^^^^^
```

Nonetheless, in our calculation let's pretend there's just one. 
Assuming we can get away with never using quote literals, the complexity for `%` strings is then 6:  (`%q`, `%Q`, `%`) * (can use, cannot use). Running complexity: 6.

We also have a `%s` for symbols. Unfortunately, it doesn't combine with the percent string literals, and it doesn't have interpolation, so strictly for symbols we have to bring back double-quote literals. 

The complexity is 2: `%s`, `:""`. Running complexity: 8 (6 + 2).

We also have percent array literals for strings (`%w`, `%W`), and for symbols (`%i`, `%I`), which also come with interpolation and escaping, or don't. For array percent literals, we also have a rubocop rule, because, for example, people tend to use commas when separating elements in a list, which is often (but not always) an error in array percent literals.

Array literal minimum complexity 2 * 2 + 2 * 2 = 8. Running complexity: 16. 

We're now comparing 16 vs 5, but that's a bit misleading. We still need `[]` array literals, and we'll still always use quote string literals and colon symbol literals. I don't know how to math this out.

What I do know is using only the primitive literals is much simpler (if a bit less convenient), combines nicely, and offers much less surface (as shown by the absence of cops).