### PR TITLE
Revert "Stop enforcing percent array literals"

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1013,6 +1013,12 @@ Lint/NonLocalExitFromIterator:
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true
 
+Lint/PercentStringArray:
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Enabled: true
+
 Lint/RandOne:
   Description: Checks for `rand(1)` calls. Such calls always return `0` and most
     likely a mistake.


### PR DESCRIPTION
Reverts Shopify/ruby-style-guide#114