### PR TITLE
Rename Performance/LstripRstrip cop to Style/Strip

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1087,9 +1087,6 @@ Performance/FixedSize:
 Performance/FlatMap:
   EnabledForFlattenWithoutParams: false
 
-Performance/LstripRstrip:
-  Enabled: true
-
 Performance/RangeInclude:
   Enabled: true
 
@@ -1147,6 +1144,9 @@ Security/Open:
   Enabled: true
 
 Lint/BigDecimalNew:
+  Enabled: true
+
+Style/Strip:
   Enabled: true
 
 Style/TrailingBodyOnClass:


### PR DESCRIPTION
RuboCop moved and renamed the cop, so this commit reflects that change.

Reference: https://github.com/rubocop-hq/rubocop/issues/6637