### PR TITLE
Enable the Rails/ApplicationRecord cop:

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1117,6 +1117,9 @@ Performance/StartWith:
 Performance/StringReplacement:
   Enabled: true
 
+Rails/ApplicationRecord:
+  Enabled: true
+
 Rails/DelegateAllowBlank:
   Enabled: true
 


### PR DESCRIPTION
Enable the Rails/ApplicationRecord cop:

- We found out few models in Shopify core whom were still inheriting
  `ActiveRecord::Base`. Since Rails 5 the advised superclass should be
  ApplicationRecord.
  This cop enforces that.

  Ref https://github.com/Shopify/shopify/pull/195409#discussion_r274387115