### PR TITLE
Move RedundantSortBy and Sample to the Style department

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -836,10 +836,16 @@ Style/RedundantParentheses:
 Style/RedundantSelf:
   Enabled: true
 
+Style/RedundantSortBy:
+  Enabled: true
+
 Layout/RescueEnsureAlignment:
   Enabled: true
 
 Style/RescueModifier:
+  Enabled: true
+
+Style/Sample:
   Enabled: true
 
 Style/SelfAssignment:
@@ -1093,16 +1099,10 @@ Performance/RangeInclude:
 Performance/RedundantMatch:
   Enabled: true
 
-Performance/RedundantSortBy:
-  Enabled: true
-
 Performance/RegexpMatch:
   Enabled: true
 
 Performance/ReverseEach:
-  Enabled: true
-
-Performance/Sample:
   Enabled: true
 
 Performance/Size:


### PR DESCRIPTION
Move `Performance/RedundantSortBy`, `Performance/UnneededSort` and `Performance/Sample` to the Style department.

For compatibility with version 0.67.0 of rubocop (as we already moved `Style/Strip`) here #121 

Changelog: https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#changes-2

Right now it is working but throwing a lot of warnings:
```
.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml: Performance/RedundantSortBy has the wrong namespace - should be Style
.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml: Performance/Sample has the wrong namespace - should be Style
```