### PR TITLE
Revert "Enable the Rails/ApplicationRecord cop:"

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1117,9 +1117,6 @@ Performance/StartWith:
 Performance/StringReplacement:
   Enabled: true
 
-Rails/ApplicationRecord:
-  Enabled: true
-
 Rails/DelegateAllowBlank:
   Enabled: true
 


### PR DESCRIPTION
This reverts commit b2fabbe587cea9e18e6383d6d40304517c48bfbd.

I accidentaly pushed this commit on master. The intended PR to be merged was this https://github.com/Shopify/ruby-style-guide/pull/122