### PR TITLE
Rename obsolete cops in 0.68.0

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -172,7 +172,7 @@ Naming/FileName:
   Regex:
   IgnoreExecutableScripts: true
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   EnforcedStyle: consistent
   SupportedStyles:
   - consistent
@@ -226,7 +226,7 @@ Layout/IndentationConsistency:
 Layout/IndentationWidth:
   Width: 2
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
   SupportedStyles:
   - special_inside_parentheses
@@ -237,7 +237,7 @@ Layout/IndentArray:
 Layout/IndentAssignment:
   IndentationWidth:
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
   SupportedStyles:
   - special_inside_parentheses


### PR DESCRIPTION
Renames Cops that were changed in 0.68.0

Layout/FirstParameterIndentation > Layout/IndentFirstArgument
Layout/IndentArray > Layout/IndentFirstArrayElement
Layout/IndentHash > Layout/IndentFirstHashElement

This will make rubocop < 0.68.0 ignore the three cops.

https://github.com/rubocop-hq/rubocop/releases/tag/v0.68.0