### PR TITLE
Disable the Sorbet department by default

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1176,3 +1176,8 @@ Style/ModuleFunction:
 
 Lint/OrderedMagicComments:
   Enabled: true
+  
+# TODO: this is due to DisabledByDefault: true not being respected
+# for custom cops. We disable it here to make it opt-in.
+Sorbet:
+  Enabled: false


### PR DESCRIPTION
Even though we have
```
AllCops:
  DisabledByDefault: true
```
The option is not respected for custom cops. This leads to Sorbet cops being ran on repos that are not using Sorbet on Policial,
because Policial loads the custom cops.
This kind of sucks for local usage because it prints a warning about unknown department, but we can remove this once upstream
fixes this issues.