### PR TITLE
Revert "Disable the Sorbet department by default"

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1176,8 +1176,3 @@ Style/ModuleFunction:
 
 Lint/OrderedMagicComments:
   Enabled: true
-  
-# TODO: this is due to DisabledByDefault: true not being respected
-# for custom cops. We disable it here to make it opt-in.
-Sorbet:
-  Enabled: false


### PR DESCRIPTION
Reverts Shopify/ruby-style-guide#126

The RuboCop config we provide here is agnostic about dependencies such as Sorbet. As such, disabling custom cops should be made in repositories that include them. 

cc @XrXr @bdewater 