### PR TITLE
Switch `Style/FrozenStringLiteralComment` to always

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -198,9 +198,8 @@ Style/FrozenStringLiteralComment:
     Add `# frozen_string_literal: true` to the top of the file. Frozen string
     literals will become the default in a future Ruby version, and we want to
     make sure we're ready.
-  EnforcedStyle: when_needed
+  EnforcedStyle: always
   SupportedStyles:
-    - when_needed
     - always
     - never
 


### PR DESCRIPTION
Relevant release notes
>#6945: Set default EnforcedStyle to always option for Style/FrozenStringLiteralComment and when_needed option is removed. (@koic)

https://github.com/rubocop-hq/rubocop/releases/tag/v0.69.0

