### PR TITLE
Set Style/AndOr.EnforcedStyle to 'conditionals':

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -38,7 +38,7 @@ Layout/AlignParameters:
   IndentationWidth:
 
 Style/AndOr:
-  EnforcedStyle: always
+  EnforcedStyle: conditionals
   SupportedStyles:
   - always
   - conditionals


### PR DESCRIPTION
Currently we complain about both of:

    a if b and c

    d and e

Setting to 'conditionals' allows the latter, which is a useful mechanism
for inverting post-conditionals.

I have often used this pattern in the past in situations like:

    raise(Foo, "something failed: #{err}") unless success

There are situations where the code would be much more readable if the
clauses could be inverted:

    success or raise(Foo, "something failed: #{err}")

The rule against use of and and or exists culturally because they bind
looser than `=`, but for control flow this is precisely what one would
want (they bind at about the same precedence as if/unless).