### PR TITLE
Disable Style/ZeroLengthPredicate:

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -919,9 +919,6 @@ Style/WhenThen:
 Style/WhileUntilDo:
   Enabled: true
 
-Style/ZeroLengthPredicate:
-  Enabled: true
-
 Layout/IndentHeredoc:
   EnforcedStyle: squiggly
 


### PR DESCRIPTION
Checking whether (for example) x.length == 0 is often better written as .empty?,
but not in all cases: for example:

   if    x.length < 100
   elsif x.length == 1
   elsif x.length == 0
   else
   end

Obviously this example is contrived but it is clearer as written than it
is if we change the condition on line 3 to `x.empty?`.