### PR TITLE
Disable Style/EachWithObject:

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -700,9 +700,6 @@ Style/DefWithParentheses:
 Style/EachForSimpleLoop:
   Enabled: true
 
-Style/EachWithObject:
-  Enabled: true
-
 Layout/ElseAlignment:
   Enabled: true
 


### PR DESCRIPTION
Both each_with_object and inject/reduce should be allowed as they have
different implied semantics:

each_with_object implies side effects, while inject/reduce imply
functionally-pure value accumulation.

This rule reduces expressiveness of code for no apparent benefit.