### PR TITLE
Allow comments for Lint/HandleExceptions

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -892,7 +892,7 @@ Lint/FormatParameterMismatch:
   Enabled: true
 
 Lint/HandleExceptions:
-  Enabled: true
+  AllowComments: true
 
 Lint/ImplicitStringConcatenation:
   Description: Checks for adjacent string literals on the same line, which could


### PR DESCRIPTION
In https://github.com/Shopify/shopify/pull/217754, `Lint/HandleExceptions` doesn't really make sense, so I ignored it. @thegedge noticed you can switch to `AllowComments: true`, which I think makes more sense to allow.