### PR TITLE
Update cops that were recently renamed

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -819,13 +819,13 @@ Layout/TrailingWhitespace:
 Style/UnlessElse:
   Enabled: true
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Style/VariableInterpolation:
@@ -956,13 +956,13 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled: true
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: true
 
-Lint/UnneededCopEnableDirective:
+Lint/RedundantCopEnableDirective:
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: true
 
 Lint/UnreachableCode:


### PR DESCRIPTION
While trying to ship a PR to `kubernetes-deploy`, I saw these [errors](https://buildkite.com/shopify/kubernetes-deploy/builds/717#308db956-866c-4d98-8fd5-ec6a93dbcd66/147-150):

<img width="1374" alt="Screen Shot 2019-10-28 at 2 58 07 PM" src="https://user-images.githubusercontent.com/411301/67708915-674b2f00-f993-11e9-87ee-6d07ef3ffd83.png">

This PR tries to fix these problems.

This is my first PR related to this and I noticed that [Style/RedundantPercentQ](https://rubocop.readthedocs.io/en/latest/cops_style/#styleredundantpercentq)  was added to `0.76`, what happens when projects use older versions of `Rubocop`?




