### PR TITLE
Rename SuppressedException cop for rubocop 0.77

### DIFF
--- a/rubocop-cli.yml
+++ b/rubocop-cli.yml
@@ -1,4 +1,4 @@
-# Recommended rubocop version: ~> 0.56.0
+# Recommended rubocop version: ~> 0.77.0
 
 inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
@@ -29,7 +29,7 @@ Style/FrozenStringLiteralComment:
 #     retry if (retries += 1) < 3
 #     handle_error(e)
 #   end
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # Allow the use of globals which occasionally makes sense in a CLI app


### PR DESCRIPTION
Similar to https://github.com/Shopify/ruby-style-guide/pull/137, but for rubocop-cli.yml

Fixes:
```
Error: The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop-https---shopify-github-io-ruby-style-guide-rubocop-cli-yml, please update it)
```