### PR TITLE
Change the LineLength namespace to Layout

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,5 @@
+# Recommended rubocop version: ~> 0.78.0
+
 AllCops:
   Exclude:
   - 'db/schema.rb'
@@ -509,7 +511,7 @@ Style/WhileUntilModifier:
 Metrics/BlockNesting:
   Max: 3
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   AllowHeredoc: true
   AllowURI: true


### PR DESCRIPTION
LineLength was moved from the Metrics namespace to the Layout namespace in Rubocop 0.78. This _should_ be backwards compatible with a warning, as Rubocop will fuzzy match on the cop name.

The Rubocop PR can be seen here: https://github.com/rubocop-hq/rubocop/pull/7542