### PR TITLE
Remove removed Style/BracesAroundHashParameters cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -78,13 +78,6 @@ Style/BlockDelimiters:
   - proc
   - it
 
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
-  SupportedStyles:
-  - braces
-  - no_braces
-  - context_dependent
-
 Layout/CaseIndentation:
   EnforcedStyle: end
   SupportedStyles:


### PR DESCRIPTION
`Style/BracesAroundHashParameters` was removed (https://github.com/rubocop-hq/rubocop/pull/7643) in Rubocop [v0.80.0](https://github.com/rubocop-hq/rubocop/releases/tag/v0.80.0) as the given style conflicts with Ruby 2.7.0's [separation of positional and keyword args](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) change.

Thus, let's remove it from our `rubocop.yml`.