### PR TITLE
Update docs to specify `require: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We offer a [default RuboCop configuration](https://shopify.github.io/ruby-style-
 you can inherit from and be in sync with this Style Guide. To use it, you can add this to your `Gemfile`:
 
   ~~~ruby
-  gem 'rubocop-shopify'
+  gem 'rubocop-shopify', require: false
   ~~~
 
 And add to the top of your project's RuboCop configuration file:


### PR DESCRIPTION
This updates the install instructions to include `require: false`. This is what `rubocop`, `rubocop-performance`, etc. do, so I assume it applies here too.

Not strictly related, but I wonder if we should indicate which Bundler groups the gem makes sense to be put in, since it isn't needed in production. I assume `:development, :test`, since it would be run locally, or in CI.