### PR TITLE
Move recommended Gemfile entry into groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ We offer a [default RuboCop configuration](https://shopify.github.io/ruby-style-
 you can inherit from and be in sync with this Style Guide. To use it, you can add this to your `Gemfile`:
 
   ~~~ruby
-  gem 'rubocop-shopify', require: false
+  group :test, :development do
+    gem 'rubocop-shopify', require: false
+  end
   ~~~
 
 And add to the top of your project's RuboCop configuration file:


### PR DESCRIPTION
Follow up to discussion in #143.

It should be recommended to include the gem in `:test` and `:development`, as it is required locally and in test/CI environments, but should not be installed in production.

I considered putting in a whole paragraph justifying why it should be in groups, and linking to the [Bundler groups documentation](https://bundler.io/guides/groups), but I realized that's probably overkill.