### PR TITLE
Add gem badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ permalink: '/index.html'
 ---
 
 # Ruby Style Guide
+[![Gem Version](https://badge.fury.io/rb/rubocop-shopify.svg)](https://badge.fury.io/rb/rubocop-shopify)
 
 Ruby is the main language at Shopify. We are primarily a Ruby shop and we are
 probably one of the largest out there. Ruby is the go-to language for new web


### PR DESCRIPTION
Add gem badge to the README now that this style guide is exposed as a gem.
<img width="905" alt="Screen Shot 2020-02-27 at 10 46 36" src="https://user-images.githubusercontent.com/1557529/75404621-74325c00-594e-11ea-87d2-02c9dc59b55e.png">

Follow-up to https://github.com/Shopify/ruby-style-guide/pull/142.