### PR TITLE
Fix Rubocop 0.81.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-shopify (1.0.0)
-      rubocop (>= 0.78.0)
+      rubocop (>= 0.81.0)
 
 GEM
   remote: https://rubygems.org/
@@ -218,7 +218,7 @@ GEM
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.19.1)
-    parser (2.7.0.3)
+    parser (2.7.0.5)
       ast (~> 2.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -230,14 +230,14 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.4)
     rouge (3.13.0)
-    rubocop (0.80.0)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     ruby-enum (0.7.2)
       i18n
     ruby-progressbar (1.10.1)

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/Shopify/ruby-style-guide/tree/v#{s.version}",
   }
 
-  s.add_dependency "rubocop", ">= 0.78.0"
+  s.add_dependency "rubocop", ">= 0.81.0"
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -872,9 +872,6 @@ Lint/EmptyEnsure:
 Lint/EmptyInterpolation:
   Enabled: true
 
-Lint/EndInMethod:
-  Enabled: true
-
 Lint/EnsureReturn:
   Enabled: true
 


### PR DESCRIPTION
Rubocop v0.81.0 removed `Lint/EndInMethod` in favour of consolidating within `Style/EngBlock`. (https://github.com/rubocop-hq/rubocop/issues/7813)

Thus, I removed our `Lint/EndInMethod` rule. We already have `Style/EngBlock` specified here:
https://github.com/Shopify/ruby-style-guide/blob/b5e4bc98012c8717c52cb2c7d797ef2503094306/rubocop.yml#L635-L636

Example failure using `rubocop-shopify-1.0.0`:
> Error: The `Lint/EndInMethod` cop has been renamed to `Style/EndBlock`.
https://app.circleci.com/pipelines/github/larouxn/carrotgram/223/workflows/e803990d-8268-463c-8d91-ce3fe3d05b62/jobs/223