### PR TITLE
Release v1.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (1.0.0)
+    rubocop-shopify (1.0.1)
       rubocop (>= 0.81.0)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "1.0.0"
+  s.version     = "1.0.1"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to the implementation of the Shopify's style" \
                     " guide for Ruby."


### PR DESCRIPTION
Release the Rubocop v0.81.0 compatibility fix. (https://github.com/Shopify/ruby-style-guide/pull/146)