### PR TITLE
Define allowed_push_host

### DIFF
--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "source_code_uri"   => "https://github.com/Shopify/ruby-style-guide/tree/v#{s.version}",
+    "allowed_push_host" => "https://rubygems.org"
   }
 
   s.add_dependency "rubocop", ">= 0.81.0"


### PR DESCRIPTION
Can't seem to deploy due to the following error. ([failed deploy](https://shipit.shopify.io/shopify/ruby-style-guide/rubygems/deploys/961749))
```
Can't release the gem: spec.metadata['allowed_push_host'] must be defined.
```