### PR TITLE
Disable Style/CaseEquality

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (1.0.2)
+    rubocop-shopify (1.0.3)
       rubocop (~> 0.85.0)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "1.0.2"
+  s.version     = "1.0.3"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Shopify's style guide for Ruby."

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -577,6 +577,7 @@ Layout/BlockEndNewline:
 
 Style/CaseEquality:
   Enabled: true
+  AllowOnConstant: true
 
 Style/CharacterLiteral:
   Enabled: true


### PR DESCRIPTION
Fixes #150

In general, I agree that `===` should be discouraged (on `Enumerable`,
`Regexp`, etc), but I don't think we can disallow it using Rubocop, and
in at least one scenario it should actually be the encouraged way of
doing things: hierarchy membership checks (aka: typechecking, but not
quite).

The idiomatic way of doing hierarchy membership checking is typically
using the `is_a?` or `kind_of?`, but this should actually be
discouraged, for two reasons.

1. `BasicObject` doesn't respond to `is_a?` and so whenever we use `is_a?`.
  When we use `is_a?` we introduce coupling (which is generally
  unnecessary), between the code that checks and the code that produces
  the objects. This practice is also prevented by Sorbet when using
  interfaces, because the implementation could very well be a
  `BasicObject`. In the Checkouts component, we've had to disable the
  check entirely since we use Sorbet with strict typing enabled.

2. When checking membership, we should always ask the collection
  rather than the item. E.g., we do `array.include?(item)` and never
  `item.contained_in?(array)`.

Because Rubocop doesn't have the required knowledge to know the type of
the receiver, the only option we have is to disable this cop.