### PR TITLE
Remove ruby version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source 'https://rubygems.org'
 
-ruby '2.7.1'
-
 gemspec
 
 gem 'github-pages', group: 'pages'


### PR DESCRIPTION
Since shipit remove this line from the Gemfile and it will leave the repository dirty.

This will fail when calling `rake release` since bundler checks if the repository is dirty before releasing the gem.