### PR TITLE
[Discussion] Disable Style/RaiseArgs cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -346,12 +346,6 @@ Style/PreferredHashMethods:
   - short
   - verbose
 
-Style/RaiseArgs:
-  EnforcedStyle: exploded
-  SupportedStyles:
-  - compact
-  - exploded
-
 Style/RedundantReturn:
   AllowMultipleReturnValues: false
 


### PR DESCRIPTION
This cop makes it more cumbersome to use custom exception classes that do not use a message as only argument to its constructor, e.g. 

``` ruby
Class CommandFailure
  def initialize(command)
    @command = command
    super("`#{command}` (pid: #{command.pid}) #{termination_status}")
  end
end

raise CommandFailure.new(command_that_failed)
```

According to the cop, I should change the raise call to 
`raise CommandFailure, command_that_failed`

While that works (accidentally), that goes against [how `raise` is documented in Ruby](https://ruby-doc.org/core-2.7.0/Kernel.html#method-i-raise): 

> With no arguments, raises the exception in $! or raises a RuntimeError if $! is nil. With a single String argument, raises a RuntimeError with the string as a message. Otherwise, the first parameter should be the name of an Exception class (or an object that returns an Exception object when sent an exception message). The optional second parameter sets the message associated with the exception, and the third parameter is an array of callback information.

(The reason why you can use exception instance is an exception instance returns itself when you call `#exception` on it.)

There are several ways to work around this and appease Rubocop:
- Use a keyword argument rather than a position arguments: `CommandFailure.new(command: command_that_failed)`
- Introduce a second argument (for which I have no reason): `CommandFailure.new(command, nil)` 
- Assign the exception to a variable first, and then raise the variable: `raise command_failure`
- `# rubocop:disable Style/RaiseArgs`

When we force people to use a workaround like this, maybe Rubocop is not the best tool to enforce this. However, we can also decide that custom exceptions with a single argument constructor are rare enough that a workaround is acceptable