### PR TITLE
Speed up Rubocop in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,6 @@
 name: Ruby
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,9 +12,15 @@ jobs:
     - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.7.1
+        ruby-version: 2.7
+    - name: Cache gems
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-rubocop-
+    - name: Install gems
+      run: bundle install --jobs 4 --retry 3 --without pages --path vendor/bundle
     - name: RuboCop
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec rubocop
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,4 @@ AllCops:
   TargetRubyVersion: 2.7
   Exclude:
     - _site/**/*
+    - vendor/**/*


### PR DESCRIPTION
## Before

From https://github.com/Shopify/ruby-style-guide/runs/700219213:  
>succeeded in 2m 8s

## After

From https://github.com/sergey-alekseev/ruby-style-guide/runs/701480507 (cold):  
>succeeded in 17s

From https://github.com/sergey-alekseev/ruby-style-guide/runs/701487963 (w/ cache):  
>succeeded in 16s

---
Replicated from [Rails](https://github.com/rails/rails/blob/100f7a7f643ae6766f406ccf1e049050199caddc/.github/workflows/rubocop.yml).