### PR TITLE
Enable Lint/DeprecatedOpenSSLConstant cop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-shopify (1.0.2)
-      rubocop (>= 0.82, < 0.86)
+      rubocop (~> 0.85.0)
 
 GEM
   remote: https://rubygems.org/

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
     "allowed_push_host" => "https://rubygems.org",
   }
 
-  s.add_dependency("rubocop", ">= 0.82", "< 0.86")
+  s.add_dependency("rubocop", "~> 0.85.0")
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1015,3 +1015,6 @@ Style/ModuleFunction:
 
 Lint/OrderedMagicComments:
   Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true


### PR DESCRIPTION
This will prevent warnings coming from the changes in https://github.com/ruby/openssl/pull/366