### PR TITLE
Fix Layout/HeredocIndentation setting

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -834,7 +834,7 @@ Style/ZeroLengthPredicate:
   Enabled: true
 
 Layout/HeredocIndentation:
-  EnforcedStyle: squiggly
+  Enabled: true
 
 Lint/AmbiguousOperator:
   Enabled: true


### PR DESCRIPTION
See https://github.com/rubocop-hq/rubocop/pull/8056#issuecomment-637927350. Actual since 804d615cde05416672623a2fbf4696be6d5dc5ff. From https://github.com/Shopify/ruby-style-guide/runs/732692117:
```
Warning: Layout/HeredocIndentation does not support EnforcedStyle parameter.

Supported parameters are:

  - Enabled

Warning: Layout/HeredocIndentation does not support EnforcedStyle parameter.

Supported parameters are:

  - Enabled
```