### PR TITLE
address discrimination when naming things

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ For more information about inheriting configuration from a gem please check
 
 * Avoid magic numbers. Use a constant and give it a useful name.
 
-* Avoid nomenclature that has (or could be interpretted to have) discriminatory origins.
+* Avoid nomenclature that has (or could be interpreted to have) discriminatory origins.
 
 ## Comments
 

--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ For more information about inheriting configuration from a gem please check
 
 * Avoid magic numbers. Use a constant and give it a useful name.
 
+* Avoid nomenclature that has (or could be interpretted to have) discriminatory origins.
 
 ## Comments
 


### PR DESCRIPTION
Updates the style guide to guide developers to avoid nomenclature that has (or could be interpreted to have) discriminatory origins. 