### PR TITLE
Add 'Avoid the usage of class instance variables'

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,46 @@ For more information about inheriting configuration from a gem please check
 * Avoid the usage of class (`@@`) variables due to their "nasty" behavior in
   inheritance.
 
+* Avoid using instance variables on singleton objects (for example, classes
+  and modules), as they might cause thread-safety issues.
+
+  ~~~ ruby
+  # bad
+  class Processor
+    class << self
+      attr_reader :thing
+
+      def call(thing, action)
+        @thing = thing
+        thing.prepare_for_action
+        process(action)
+      end
+
+      private
+
+      def process(action)
+        Actions.for(action).perform_with(thing)
+      end
+    end
+  end
+
+  # good
+  class Processor
+    class << self
+      def call(thing, action)
+        thing.prepare_for_action
+        process(action, thing)
+      end
+
+      private
+
+      def process(action, thing)
+        Actions.for(action).perform_with(thing)
+      end
+    end
+  end
+  ~~~
+
 * Indent the `public`, `protected`, and `private` methods as much as the method
   definitions they apply to. Leave one blank line above the visibility modifier
   and one blank line below in order to emphasize that it applies to all methods


### PR DESCRIPTION
Per the discussion on Slack earlier today, where we reviewed internal code where seemingly the authors were not aware of the `self << class` and used class instance variables instead of instance variables.