### PR TITLE
rubocop 0.89 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-shopify (1.0.4)
-      rubocop (>= 0.85, < 0.89)
+      rubocop (~> 0.89.0)
 
 GEM
   remote: https://rubygems.org/
@@ -230,7 +230,7 @@ GEM
     regexp_parser (1.7.1)
     rexml (3.2.4)
     rouge (3.19.0)
-    rubocop (0.88.0)
+    rubocop (0.89.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -239,8 +239,8 @@ GEM
       rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.1.0)
-      parser (>= 2.7.0.1)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
     ruby-enum (0.8.0)
       i18n
     ruby-progressbar (1.10.1)

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
     "allowed_push_host" => "https://rubygems.org",
   }
 
-  s.add_dependency("rubocop", ">= 0.85", "< 0.89")
+  s.add_dependency("rubocop", "~> 0.89.0")
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -675,7 +675,7 @@ Style/LineEndConcatenation:
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
-Style/MethodMissingSuper:
+Lint/MissingSuper:
   Enabled: true
 
 Style/MissingRespondToMissing:
@@ -965,7 +965,7 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/UselessElseWithoutRescue:


### PR DESCRIPTION
Sadly, 0.89 renames some cops (Lint/MissingSuper, Lint/BinaryOperatorWithIdenticalOperands).

0.88 will not accept the new names, while 0.89 will not accept the old names. I would have expected a grace period, but alas.