### PR TITLE
Bump gem version from 1.0.4->1.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (1.0.4)
+    rubocop-shopify (1.0.5)
       rubocop (~> 0.89.0)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "1.0.4"
+  s.version     = "1.0.5"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Shopify's style guide for Ruby."


### PR DESCRIPTION
This gets the goodness from #177 out to the world.

```sh
james@jamess-mbp ➜ ~/s/g/S/ruby-style-guide git:(master) ✗ rg 1.0.4
james@jamess-mbp ➜ ~/s/g/S/ruby-style-guide git:(master) ✗ rg 1.0.5
Gemfile.lock
4:    rubocop-shopify (1.0.5)
252:    safe_yaml (1.0.5)

rubocop-shopify.gemspec
6:  s.version     = "1.0.5"
```

Full diff: https://github.com/Shopify/ruby-style-guide/compare/v1.0.4...cut-1.0.5