### PR TITLE
Transfer ownership of the Ruby Style Guide to the Ruby and Rails team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @volmer @rafaelfranca @Shopify/technical-leadership-team
+* @volmer @rafaelfranca @Shopify/rails


### PR DESCRIPTION
The Ruby and Rails Infrastructure Team at Shopify has the mandate of defining best practices and modernizing development in Ruby and Rails at Shopify. Given the team's mandate I think it's better for this style guide to be maintained by that team. 

In #116 I included the Technical Leadership Team as co-owner of this repo, as the TLT's mandate was to oversee engineering in general at Shopify. Fast-forward to today, the Style Guide could benefit of a team with a more specific mandate for its maintenance. Evolving the style guide is also connected to roadmaps of the Ruby and Rails infrastructure team, which will develop and publish best practices for Rails, Testing, and Architecture for new and existing apps at Shopify.

cc @Shopify/rails @Shopify/technical-leadership-team 