### PR TITLE
[Style/MethodCallWithArgsParentheses] Exclude nested Gemfiles

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -264,7 +264,7 @@ Style/MethodCallWithArgsParentheses:
   - raise
   - puts
   Exclude:
-  - Gemfile
+  - '**/Gemfile'
 
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses


### PR DESCRIPTION
Some projects (mainly gems with fixture/dummy apps or apps with embedded gems) have nested gemfiles. They should also be excluded from `Style/MethodCallWithArgsParentheses`.