### PR TITLE
Add rule against memoizing possibly falsely values

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,21 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
   @enabled = true unless defined?(@enabled)
   ~~~
 
+* Avoid using `||=` to memoize possibly falsey (`false` or `nil`) values.
+
+  ~~~ ruby
+  # bad - will repeat lookup each time if it returns nil
+  def existing_record
+    @existing_record ||= expensive_lookup_that_might_return_nil
+  end
+
+  # good
+  def existing_record
+    return @existing_record if defined?(@existing_record)
+    @existing_record = expensive_lookup_that_might_return_nil
+  end
+  ~~~
+
 * Avoid spaces between a method name and the opening parenthesis.
 
 * Prefer the lambda literal syntax over `lambda`.


### PR DESCRIPTION
This adds a rule elaborating on some of the pitfalls of `||=`.

_"Avoid using `||=` to initialize boolean variables"_ provides a good explanation about `false` not being safe to use with `||=`, but cases where the value can be `nil` (e.g. not found) should also be considered.

----

Follow up to discussion in https://github.com/Shopify/ruby-style-guide/pull/193/files#r490432383