### PR TITLE
Update the CamelCase docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,8 +441,7 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 
 * Use `snake_case` for symbols, methods, and variables.
 
-* Use `CamelCase` for classes and modules, but keep acronyms like HTTP, RFC, XML
-  uppercase.
+* Use `CamelCase` for classes and modules.
 
 * Use `snake_case` for naming files and directories, e.g. `hello_world.rb`.
 


### PR DESCRIPTION
Significant effort was done on the @Shopify/kernel-architecture-patterns team to remove custom inflections as they became problematic with the introduction of [Packwerk](https://www.github.com/Shopify/packwerk). 

Discussion has begun as to whether or not the Style Guide should be pushing acronyms to be in all caps (i.e. `HTTP`, `XML`, etc.) or follow the current state which doesn't require custom inflections (i.e. `Http`, `Xml`, etc.).