### PR TITLE
Mark Style/FrozenStringLiteralComment as safe to autocorrect

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -195,6 +195,7 @@ Style/FrozenStringLiteralComment:
   SupportedStyles:
     - always
     - never
+  SafeAutoCorrect: true
 
 Style/GlobalVars:
   AllowedVariables: []


### PR DESCRIPTION
There was internal discussion regarding FrozenStringLiteralComment cop being deemed unsafe to autocorrect in Rubocop. This recent change threw people off that expect `-a` to fix FrozenStringLiteralComment errors as it has done in the past, eg. https://github.com/Shopify/rubocop-sorbet/issues/46. 

This past behaviour along with the assumption that we expect developers to write code that is frozen string safe lead to the decision of keeping the existing practice of `-a` autocorrecting this cop, even though it was marked as unsafe to autocorrect in rubocop.

Rubocop PRs that made autocorrect unsafe: https://github.com/rubocop-hq/rubocop/pull/7307 & https://github.com/rubocop-hq/rubocop/pull/8529