### PR TITLE
Exclude node_modules directory

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
-  - 'db/schema.rb'
+    - 'db/schema.rb'
+    - 'node_modules/**/*'
   DisabledByDefault: true
   StyleGuideBaseURL: https://shopify.github.io/ruby-style-guide/
 


### PR DESCRIPTION
In a new Rails project I get these

```
node_modules/node-sass/src/libsass/extconf.rb:5:1: C: Style/GlobalVars: Do not introduce global variables.
$CFLAGS << " #{ENV['CFLAGS']}"
^^^^^^^
node_modules/node-sass/src/libsass/extconf.rb:6:1: C: Style/GlobalVars: Do not introduce global variables.
$LIBS << " #{ENV['LIBS']}"
^^^^^
```

Should we exclude the `node_directory` by default as it's a third party?