### PR TITLE
Add Layout/ArgumentAlignment

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -20,6 +20,12 @@ Style/Alias:
   - prefer_alias
   - prefer_alias_method
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+  SupportedStyles:
+    - with_first_argument
+    - with_fixed_indentation
+
 Layout/HashAlignment:
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
@@ -164,14 +170,6 @@ Naming/FileName:
   ExpectMatchingDefinition: false
   Regex:
   IgnoreExecutableScripts: true
-
-Layout/FirstArgumentIndentation:
-  EnforcedStyle: consistent
-  SupportedStyles:
-  - consistent
-  - special_for_inner_method_call
-  - special_for_inner_method_call_in_parentheses
-  IndentationWidth:
 
 Style/For:
   EnforcedStyle: each


### PR DESCRIPTION
Add the Layout/ArgumentAlignment rule definition, with params matching
~Layout/FirstArgumentIndentation~ Layout/ParameterAlignment. Prior to this
rule, this code would have been valid:

```ruby
method_call(
  1,
    2,
  3,
)
```

I argue that it should not be – params should all have the same
indentation.

By enforcing `with_fixed_indentation`, the following becomes invalid:
```ruby
puts 1,
     2
```

What do you think of this rule? If that's too strict, is there a way to support both
styles (`with_fixed_indentation` and `with_first_argument`), while still outlawing
the above offending code?