### PR TITLE
Replace actions/setup-ruby with ruby/setup-ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,18 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1.1.3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7.2'
-    - name: Cache gems
-      uses: actions/cache@v2.1.4
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rubocop-
-    - name: Install gems
-      run: bundle install --jobs 4 --retry 3 --without pages --path vendor/bundle
+        bundler-cache: true
     - name: RuboCop
       run: bundle exec rubocop


### PR DESCRIPTION
[actions/setup-ruby is deprecated](https://github.com/actions/setup-ruby).

[ruby/setup-ruby](https://github.com/ruby/setup-ruby)...

- offers the [`bundler-cache: true`](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically) option to cache and install gems
  automatically, we don't need to do that manually anymore
- supports [inferring the Ruby version from `.ruby-version`](https://github.com/ruby/setup-ruby#supported-version-syntax)
- [recommends `@v1`](https://github.com/ruby/setup-ruby#versioning), instead of a more granular one, to get updates