### PR TITLE
Only build on `push`, not on `pull_request` too

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,6 @@
 name: Ruby
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
Listening for both events triggers a redundant build. All PRs will have involved pushing a branch, so the build will have already been triggered. There is no need to trigger it again.