### PR TITLE
Allow RuboCop CLI config to inherit from the RuboCop Shopify gem

### DIFF
--- a/rubocop-cli.yml
+++ b/rubocop-cli.yml
@@ -1,5 +1,6 @@
-inherit_from:
-  - http://shopify.github.io/ruby-style-guide/rubocop.yml
+inherit_gem:
+  rubocop-shopify:
+    - rubocop-cli.yml
 
 AllCops:
   # We don't always use bundler to make for a faster boot time.


### PR DESCRIPTION
The RuboCop CLI config was inheriting from the deprecated remote config via URL. This commit changes it to inherit from the RuboCop Shopify gem directly.