### PR TITLE
Fix rubocop-cli.yml to inherit from rubocop.yml

### DIFF
--- a/rubocop-cli.yml
+++ b/rubocop-cli.yml
@@ -1,6 +1,6 @@
 inherit_gem:
   rubocop-shopify:
-    - rubocop-cli.yml
+    - rubocop.yml
 
 AllCops:
   # We don't always use bundler to make for a faster boot time.


### PR DESCRIPTION
Current code causes an infinite recursion when inheriting from rubocop-cli.yml