### PR TITLE
Deploy rubocop.yml to Github pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -14,6 +14,7 @@ module.exports = function (eleventyConfig) {
   })
   eleventyConfig.setUseGitIgnore(false)
   eleventyConfig.addPassthroughCopy('CNAME')
+  eleventyConfig.addPassthroughCopy('rubocop.yml')
   eleventyConfig.addPassthroughCopy({
     'node_modules/@fortawesome/fontawesome-free/webfonts': 'fonts/fontawesome'
   })


### PR DESCRIPTION
I noticed after the latest deploy (I'm guessing https://github.com/Shopify/ruby-style-guide/pull/240) I could no longer access https://ruby-style-guide.shopify.dev/rubocop.yml
<img width="1220" alt="Screen Shot 2021-03-23 at 3 22 45 PM" src="https://user-images.githubusercontent.com/16085982/112205848-9fd45400-8beb-11eb-80b3-93bd3cde1ac9.png">


I took a quick look and noticed the rubocop.yml file was missing from the `gh-pages` branch

I added `rubocop.yml` as a passthrough copy file in the eleventy config.

Tried it on my local (`npm run build && npm run serve`) and was able to access the rubocop.yml file

I also noticed the file `rubocop-cli.yml`, I've never used it but let me know if that should be deployed to and I can add it in