### PR TITLE
Inherit `Include` and `Exclude` paths from RuboCop

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ And add to the top of your project's RuboCop configuration file:
     rubocop-shopify: rubocop.yml
   ~~~
 
+Any `Include` or `Exclude` configuration provided will be merged with RuboCop's defaults.
+
 For more information about inheriting configuration from a gem please check
 [RuboCop's
 documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem).

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,9 @@
+inherit_mode:
+  merge:
+    - Exclude
+    - Include
+
 AllCops:
-  Exclude:
-  - 'db/schema.rb'
   DisabledByDefault: true
   StyleGuideBaseURL: https://shopify.github.io/ruby-style-guide/
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -59,7 +59,10 @@ AllCops:
   - "**/Vagabondfile"
   - "**/Vagrantfile"
   Exclude:
-  - "/db/schema.rb"
+  - "/node_modules/**/*"
+  - "/tmp/**/*"
+  - "/vendor/**/*"
+  - "/.git/**/*"
   DefaultFormatter: progress
   DisplayCopNames: true
   DisplayStyleGuide: false
@@ -3574,3 +3577,8 @@ Style/ZeroLengthPredicate:
   Safe: false
   VersionAdded: '0.37'
   VersionChanged: '0.39'
+inherit_mode:
+  Enabled: true
+  merge:
+  - Exclude
+  - Include


### PR DESCRIPTION
This was originally intended to prevent CI from inadvertently finding a `.rubocop.yml` in `node_modules` and applying that config.

The scope has expanded to provide a better out-of-the-box experience. When a user of the gem configures an `Include` or `Exclude`, this will now be merged with RuboCop's default configuration. Previously, this would have completely replaced RuboCop's defaults. 

This PR also removes the Rails-specific exclusion of `db/schema.rb` which should now be handled in the repo's own configuration.