### PR TITLE
Inherit supported styles config from RuboCop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -12,180 +12,82 @@ Lint/AssignmentInCondition:
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent
-  SupportedStyles:
-  - outdent
-  - indent
-  IndentationWidth:
 
 Style/Alias:
   EnforcedStyle: prefer_alias_method
-  SupportedStyles:
-  - prefer_alias
-  - prefer_alias_method
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
-  SupportedStyles:
-    - with_first_argument
-    - with_fixed_indentation
 
 Layout/HashAlignment:
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: ignore_implicit
-  SupportedLastArgumentHashStyles:
-  - always_inspect
-  - always_ignore
-  - ignore_implicit
-  - ignore_explicit
 
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
-  SupportedStyles:
-  - with_first_parameter
-  - with_fixed_indentation
-  IndentationWidth:
 
 Style/AndOr:
   EnforcedStyle: always
-  SupportedStyles:
-  - always
-  - conditionals
 
 Style/BarePercentLiterals:
   EnforcedStyle: bare_percent
-  SupportedStyles:
-  - percent_q
-  - bare_percent
 
 Style/BlockDelimiters:
   EnforcedStyle: line_count_based
-  SupportedStyles:
-  - line_count_based
-  - semantic
-  - braces_for_chaining
-  ProceduralMethods:
-  - benchmark
-  - bm
-  - bmbm
-  - create
-  - each_with_object
-  - measure
-  - new
-  - realtime
-  - tap
-  - with_object
-  FunctionalMethods:
-  - let
-  - let!
-  - subject
-  - watch
-  IgnoredMethods:
-  - lambda
-  - proc
-  - it
 
 Layout/CaseIndentation:
   EnforcedStyle: end
-  SupportedStyles:
-  - case
-  - end
   IndentOneStep: false
-  IndentationWidth:
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested
-  SupportedStyles:
-  - nested
-  - compact
 
 Style/ClassCheck:
   EnforcedStyle: is_a?
-  SupportedStyles:
-  - is_a?
-  - kind_of?
 
 Style/CommandLiteral:
   EnforcedStyle: percent_x
-  SupportedStyles:
-  - backticks
-  - percent_x
-  - mixed
   AllowInnerBackticks: false
 
 Style/CommentAnnotation:
-  Keywords:
-  - TODO
-  - FIXME
-  - OPTIMIZE
-  - HACK
-  - REVIEW
+  Enabled: true
 
 Style/ConditionalAssignment:
   EnforcedStyle: assign_to_condition
-  SupportedStyles:
-  - assign_to_condition
-  - assign_inside_condition
   SingleLineConditionsOnly: true
 
 Layout/DotPosition:
   EnforcedStyle: leading
-  SupportedStyles:
-  - leading
-  - trailing
 
 Style/EmptyElse:
   EnforcedStyle: both
-  SupportedStyles:
-  - empty
-  - nil
-  - both
 
 Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: false
 
 Layout/EmptyLinesAroundBlockBody:
   EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
 
 Layout/EmptyLinesAroundClassBody:
   EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - empty_lines_except_namespace
-  - no_empty_lines
 
 Layout/EmptyLinesAroundModuleBody:
   EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - empty_lines_except_namespace
-  - no_empty_lines
 
 Layout/ExtraSpacing:
   AllowForAlignment: true
   ForceEqualSignAlignment: false
 
 Naming/FileName:
-  Exclude: []
   ExpectMatchingDefinition: false
-  Regex:
   IgnoreExecutableScripts: true
 
 Style/For:
   EnforcedStyle: each
-  SupportedStyles:
-  - for
-  - each
 
 Style/FormatString:
   EnforcedStyle: format
-  SupportedStyles:
-  - format
-  - sprintf
-  - percent
 
 Style/FrozenStringLiteralComment:
   Details: >-
@@ -193,64 +95,37 @@ Style/FrozenStringLiteralComment:
     literals will become the default in a future Ruby version, and we want to
     make sure we're ready.
   EnforcedStyle: always
-  SupportedStyles:
-    - always
-    - never
   SafeAutoCorrect: true
 
 Style/GlobalVars:
-  AllowedVariables: []
+  Enabled: true
 
 Style/HashSyntax:
   EnforcedStyle: ruby19
-  SupportedStyles:
-  - ruby19
-  - hash_rockets
-  - no_mixed_keys
-  - ruby19_no_mixed_keys
   UseHashRocketsWithSymbolValues: false
   PreferHashRocketsForNonAlnumEndingSymbols: false
 
 Layout/IndentationConsistency:
   EnforcedStyle: normal
-  SupportedStyles:
-  - normal
-  - rails
 
 Layout/IndentationWidth:
   Width: 2
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
-  SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-  - align_brackets
-  IndentationWidth:
 
 Layout/AssignmentIndentation:
-  IndentationWidth:
+  Enabled: true
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
-  SupportedStyles:
-  - special_inside_parentheses
-  - consistent
-  - align_braces
-  IndentationWidth:
 
 Style/LambdaCall:
   EnforcedStyle: call
-  SupportedStyles:
-  - call
-  - braces
 
 Style/Next:
   EnforcedStyle: skip_modifier_ifs
   MinBodyLength: 3
-  SupportedStyles:
-  - skip_modifier_ifs
-  - always
 
 Style/NonNilCheck:
   IncludeSemanticChanges: false
@@ -270,99 +145,52 @@ Style/MethodCallWithArgsParentheses:
 
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses
-  SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
-  - require_no_parentheses_except_multiline
 
 Naming/MethodName:
   EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
 
 Layout/MultilineArrayBraceLayout:
   EnforcedStyle: symmetrical
-  SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
 
 Layout/MultilineHashBraceLayout:
   EnforcedStyle: symmetrical
-  SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
 
 Layout/MultilineMethodCallBraceLayout:
   EnforcedStyle: symmetrical
-  SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
-  SupportedStyles:
-  - aligned
-  - indented
-  - indented_relative_to_receiver
   IndentationWidth: 2
 
 Layout/MultilineMethodDefinitionBraceLayout:
   EnforcedStyle: symmetrical
-  SupportedStyles:
-  - symmetrical
-  - new_line
-  - same_line
 
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
-  SupportedOctalStyles:
-  - zero_with_o
-  - zero_only
 
 Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true
 
 Style/PercentQLiterals:
   EnforcedStyle: lower_case_q
-  SupportedStyles:
-  - lower_case_q
-  - upper_case_q
 
 Naming/PredicateName:
   NamePrefix:
   - is_
   ForbiddenPrefixes:
   - is_
-  AllowedMethods:
-  - is_a?
-  Exclude:
-  - 'spec/**/*'
 
 Style/PreferredHashMethods:
   EnforcedStyle: short
-  SupportedStyles:
-  - short
-  - verbose
 
 Style/RaiseArgs:
   EnforcedStyle: exploded
-  SupportedStyles:
-  - compact
-  - exploded
 
 Style/RedundantReturn:
   AllowMultipleReturnValues: false
 
 Style/RegexpLiteral:
   EnforcedStyle: mixed
-  SupportedStyles:
-  - slashes
-  - percent_r
-  - mixed
   AllowInnerSlashes: false
 
 Style/SafeNavigation:
@@ -377,10 +205,6 @@ Style/Semicolon:
 
 Style/SignalException:
   EnforcedStyle: only_raise
-  SupportedStyles:
-  - only_raise
-  - only_fail
-  - semantic
 
 Style/SingleLineMethods:
   AllowIfMethodIsEmpty: true
@@ -390,15 +214,9 @@ Layout/SpaceBeforeFirstArg:
 
 Style/SpecialGlobalVars:
   EnforcedStyle: use_english_names
-  SupportedStyles:
-  - use_perl_names
-  - use_english_names
 
 Style/StabbyLambdaParentheses:
   EnforcedStyle: require_parentheses
-  SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
 
 Style/StringLiterals:
   Enabled: true
@@ -411,15 +229,9 @@ Style/StringLiteralsInInterpolation:
 
 Layout/SpaceAroundBlockParameters:
   EnforcedStyleInsidePipes: no_space
-  SupportedStylesInsidePipes:
-  - space
-  - no_space
 
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
 
 Layout/SpaceAroundOperators:
   AllowForAlignment: true
@@ -427,79 +239,37 @@ Layout/SpaceAroundOperators:
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: space
-  SupportedStyles:
-  - space
-  - no_space
 
 Layout/SpaceInsideBlockBraces:
   EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
   EnforcedStyleForEmptyBraces: no_space
   SpaceBeforeBlockParameters: true
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: no_space
-  SupportedStyles:
-  - space
-  - no_space
-  - compact
 
 Layout/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
-  SupportedStyles:
-  - space
-  - no_space
 
 Style/SymbolProc:
-  IgnoredMethods:
-  - respond_to
-  - define_method
+  Enabled: true
 
 Style/TernaryParentheses:
   EnforcedStyle: require_no_parentheses
-  SupportedStyles:
-  - require_parentheses
-  - require_no_parentheses
   AllowSafeAssignment: true
 
 Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
-  SupportedStyles:
-  - final_newline
-  - final_blank_line
 
 Style/TrivialAccessors:
   ExactNameMatch: true
   AllowPredicates: true
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  AllowedMethods:
-  - to_ary
-  - to_a
-  - to_c
-  - to_enum
-  - to_h
-  - to_hash
-  - to_i
-  - to_int
-  - to_io
-  - to_open
-  - to_path
-  - to_proc
-  - to_r
-  - to_regexp
-  - to_str
-  - to_s
-  - to_sym
 
 Naming/VariableName:
   EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
 
 Style/WhileUntilModifier:
   Enabled: true
@@ -524,29 +294,15 @@ Metrics/ParameterLists:
 
 Layout/BlockAlignment:
   EnforcedStyleAlignWith: either
-  SupportedStylesAlignWith:
-  - either
-  - start_of_block
-  - start_of_line
 
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
-  SupportedStylesAlignWith:
-  - keyword
-  - variable
-  - start_of_line
 
 Layout/DefEndAlignment:
   EnforcedStyleAlignWith: start_of_line
-  SupportedStylesAlignWith:
-  - start_of_line
-  - def
 
 Lint/InheritException:
   EnforcedStyle: runtime_error
-  SupportedStyles:
-  - runtime_error
-  - standard_error
 
 Lint/UnusedBlockArgument:
   IgnoreEmptyBlocks: true
@@ -891,12 +647,10 @@ Lint/SuppressedException:
   AllowComments: true
 
 Lint/ImplicitStringConcatenation:
-  Description: Checks for adjacent string literals on the same line, which could
-    better be represented as a single string literal.
+  Enabled: true
 
 Lint/IneffectiveAccessModifier:
-  Description: Checks for attempts to use `private` or `protected` to set the visibility
-    of a class method, which does not work.
+  Enabled: true
 
 Lint/LiteralAsCondition:
   Enabled: true
@@ -905,15 +659,13 @@ Lint/LiteralInInterpolation:
   Enabled: true
 
 Lint/Loop:
-  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
-    for post-loop tests.
+  Enabled: true
 
 Lint/NestedMethodDefinition:
   Enabled: true
 
 Lint/NextWithoutAccumulator:
-  Description: Do not omit the accumulator when calling `next` in a `reduce`/`inject`
-    block.
+  Enabled: true
 
 Lint/NonLocalExitFromIterator:
   Enabled: true
@@ -928,8 +680,7 @@ Lint/PercentSymbolArray:
   Enabled: true
 
 Lint/RandOne:
-  Description: Checks for `rand(1)` calls. Such calls always return `0` and most
-    likely a mistake.
+  Enabled: true
 
 Lint/RequireParentheses:
   Enabled: true
@@ -1005,16 +756,13 @@ Style/TrailingBodyOnModule:
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
-  Enabled: true
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
-  Enabled: true
 
 Layout/SpaceInsideReferenceBrackets:
   EnforcedStyle: no_space
   EnforcedStyleForEmptyBrackets: no_space
-  Enabled: true
 
 Style/ModuleFunction:
   EnforcedStyle: extend_self

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -176,6 +176,7 @@ Layout/AccessModifierIndentation:
   SupportedStyles:
   - outdent
   - indent
+  IndentationWidth:
 Layout/ArgumentAlignment:
   Description: Align the arguments of a method call if they span more than one line.
   StyleGuide: "#no-double-indent"
@@ -204,6 +205,7 @@ Layout/AssignmentIndentation:
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.77'
+  IndentationWidth:
 Layout/BeginEndAlignment:
   Description: Align ends corresponding to begins correctly.
   Enabled: false
@@ -236,6 +238,7 @@ Layout/CaseIndentation:
   - case
   - end
   IndentOneStep: false
+  IndentationWidth:
 Layout/ClassStructure:
   Description: Enforces a configured order of definitions within a class body.
   StyleGuide: "#consistent-classes"
@@ -384,7 +387,10 @@ Layout/EmptyLinesAroundClassBody:
   SupportedStyles:
   - empty_lines
   - empty_lines_except_namespace
+  - empty_lines_special
   - no_empty_lines
+  - beginning_only
+  - ending_only
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Description: Keeps track of empty lines around exception handling keywords.
   StyleGuide: "#empty-lines-around-bodies"
@@ -404,6 +410,7 @@ Layout/EmptyLinesAroundModuleBody:
   SupportedStyles:
   - empty_lines
   - empty_lines_except_namespace
+  - empty_lines_special
   - no_empty_lines
 Layout/EndAlignment:
   Description: Align ends correctly.
@@ -454,6 +461,7 @@ Layout/FirstArrayElementIndentation:
   - special_inside_parentheses
   - consistent
   - align_brackets
+  IndentationWidth:
 Layout/FirstArrayElementLineBreak:
   Description: Checks for a line break before the first element in a multi-line array.
   Enabled: false
@@ -468,6 +476,7 @@ Layout/FirstHashElementIndentation:
   - special_inside_parentheses
   - consistent
   - align_braces
+  IndentationWidth:
 Layout/FirstHashElementLineBreak:
   Description: Checks for a line break before the first element in a multi-line hash.
   Enabled: false
@@ -534,7 +543,7 @@ Layout/IndentationConsistency:
   EnforcedStyle: normal
   SupportedStyles:
   - normal
-  - rails
+  - indented_internal_methods
   Reference:
   - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 Layout/IndentationStyle:
@@ -695,6 +704,7 @@ Layout/ParameterAlignment:
   SupportedStyles:
   - with_first_parameter
   - with_fixed_indentation
+  IndentationWidth:
 Layout/RescueEnsureAlignment:
   Description: Align rescues and ensures correctly.
   Enabled: true
@@ -1744,6 +1754,7 @@ Naming/FileName:
   Exclude: []
   ExpectMatchingDefinition: false
   CheckDefinitionPathHierarchy: true
+  Regex:
   IgnoreExecutableScripts: true
   AllowedAcronyms:
   - CLI
@@ -2047,6 +2058,7 @@ Style/BlockDelimiters:
   - line_count_based
   - semantic
   - braces_for_chaining
+  - always_braces
   ProceduralMethods:
   - benchmark
   - bm
@@ -2202,6 +2214,7 @@ Style/CommentAnnotation:
   - OPTIMIZE
   - HACK
   - REVIEW
+  - NOTE
 Style/CommentedKeyword:
   Description: Do not place comments on the same line as certain keywords.
   Enabled: false
@@ -2419,8 +2432,8 @@ Style/For:
   VersionChanged: '0.59'
   EnforcedStyle: each
   SupportedStyles:
-  - for
   - each
+  - for
 Style/FormatString:
   Description: Enforce the use of Kernel#sprintf, Kernel#format or String#%.
   StyleGuide: "#sprintf"
@@ -2453,6 +2466,7 @@ Style/FrozenStringLiteralComment:
   EnforcedStyle: always
   SupportedStyles:
   - always
+  - always_true
   - never
   SafeAutoCorrect: true
   Details: 'Add `# frozen_string_literal: true` to the top of the file. Frozen string
@@ -3419,6 +3433,7 @@ Style/TernaryParentheses:
   SupportedStyles:
   - require_parentheses
   - require_no_parentheses
+  - require_parentheses_when_complex
   AllowSafeAssignment: true
 Style/TrailingBodyOnClass:
   Description: Class body goes below class statement.


### PR DESCRIPTION
We are unnecessarily defining our own supported styles for cops. 

This was a leftover from the migration to `DisableByDefault` years back, when I dumped the entire config for all enabled cops. Although we do want to enable cops explicitly and set their preferred configs, we can still use RuboCop's supported styles config without breaking anything.

Thanks to the new test for config we can see that this change does not modify our resulting config in any significant way.

