### PR TITLE
Enable `Lint/Syntax` cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1024,3 +1024,6 @@ Lint/OrderedMagicComments:
 
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
+
+Lint/Syntax:
+  Enabled: true

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1471,7 +1471,7 @@ Lint/SymbolConversion:
   - consistent
 Lint/Syntax:
   Description: Checks for syntax errors.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.9'
 Lint/ToEnumArguments:
   Description: This cop ensures that `to_enum`/`enum_for`, called for the current


### PR DESCRIPTION
I noticed that VS Code wasn't displaying syntax errors for projects using `rubocop-shopify`, but was for other projects.

This is because the [Lint/Syntax](https://docs.rubocop.org/rubocop/cops_lint.html#lintsyntax) cop is disabled.

To verify this is safe to enable, I've tested it against `Shopify/shopify` (I added one intentional syntax error):

https://github.com/Shopify/shopify/tree/andyw8/experiement-enable-lint-syntax-rubocop