### PR TITLE
Add style word array bracket to .rubocop.yml

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -631,7 +631,7 @@ Style/SwapValues:
   Enabled: false
 
 Style/SymbolArray:
-  Enabled: false
+  EnforcedStyle: brackets
 
 Style/TrailingBodyOnMethodDefinition:
   Enabled: false
@@ -655,7 +655,7 @@ Style/UnpackFirst:
   Enabled: false
 
 Style/WordArray:
-  Enabled: false
+  EnforcedStyle: brackets
 
 Style/YodaCondition:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3401,10 +3401,10 @@ Style/SwapValues:
 Style/SymbolArray:
   Description: Use %i or %I for arrays of symbols.
   StyleGuide: "#percent-i"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.49'
-  EnforcedStyle: percent
+  EnforcedStyle: brackets
   MinSize: 2
   SupportedStyles:
   - percent
@@ -3563,10 +3563,10 @@ Style/WhileUntilModifier:
 Style/WordArray:
   Description: Use %w or %W for arrays of words.
   StyleGuide: "#percent-w"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
-  EnforcedStyle: percent
+  EnforcedStyle: brackets
   SupportedStyles:
   - percent
   - brackets


### PR DESCRIPTION
I am not sure if I am missing anything, but according to the style guide, literal array syntax is preferred over `%i` and `%w`.
```
# bad
STATES = %w(draft open closed)

# good
STATES = ["draft", "open", "closed"]
```

- However, looking at the current Cop enabled, [Style/WordArray](https://msp-greg.github.io/rubocop/RuboCop/Cop/Style/WordArray.html) is not included inside.  I have extended it manually for my project, so that I will get linting message like this:
![image](https://user-images.githubusercontent.com/40255418/115135798-d3b96280-a04d-11eb-8ad7-0b1dd40d51e5.png)

- Therefore, I am making this PR, to add in the `Style/WordArray` and set it to `bracket` as this is the preferred style as mentioned in the style guide.
