### PR TITLE
Use Layout/BeginEndAlignment style start_of_line

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
   end
   ~~~
 
+* When assigning the result of a begin block, align rescue/ensure/end with the start of the line
+
+  ~~~ ruby
+  # bad
+  host = begin
+           URI.parse(value).host
+         rescue URI::Error
+           nil
+         end
+
+  # good
+  host = begin
+    URI.parse(value).host
+  rescue URI::Error
+    nil
+  end
+  ~~~
+
 * Use empty lines between method definitions and also to break up methods into
   logical paragraphs internally.
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -542,6 +542,9 @@ Layout/DefEndAlignment:
   - start_of_line
   - def
 
+Layout/BeginEndAlignment:
+  Enabled: true
+
 Lint/InheritException:
   EnforcedStyle: runtime_error
   SupportedStyles:

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -206,7 +206,7 @@ Layout/AssignmentIndentation:
   VersionChanged: '0.77'
 Layout/BeginEndAlignment:
   Description: Align ends corresponding to begins correctly.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.91'
   EnforcedStyleAlignWith: start_of_line
   SupportedStylesAlignWith:


### PR DESCRIPTION
## Problem

Currently we disable the Layout/RescueEnsureAlignment in Shopify Core and have a TODO to re-enable it.  There used to be a comment saying to renable it when https://github.com/rubocop/rubocop/issues/6433 was fixed but it didn't get renabled after that, I assume because it doesn't have the desired effect.

For instance, it autocorrects with changes like this

```ruby
       host = begin
         URI.parse(value).host
-      rescue URI::Error
-        nil
+             rescue URI::Error
+               nil
       end
```

which is pretty close to the original issue reported in that issue, with the difference being the presence of the `begin` keyword.

## Solution

Using the Layout/BeginEndAlignment style of start_of_line avoids the above problem and uses a style that seems consistent with our existing coding style.  This style is used by the [Layout/RescueEnsureAlignment](https://github.com/rubocop/rubocop/blob/v1.12.1/lib/rubocop/cop/layout/rescue_ensure_alignment.rb#L185-L197) cop when it is enabled.

If this is too disruptive a change to introduce without a major release, the alternative would be to disable the Layout/RescueEnsureAlignment cop since it doesn't have the desired behaviour without `Layout/BeginEndAlignment` also enabled.