### PR TITLE
Enable `Lint/SymbolConversion`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -253,7 +253,7 @@ Lint/StructNewOverride:
   Enabled: false
 
 Lint/SymbolConversion:
-  Enabled: false
+  Enabled: true
 
 Lint/ToEnumArguments:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1497,7 +1497,7 @@ Lint/SuppressedException:
   VersionChanged: '1.12'
 Lint/SymbolConversion:
   Description: Checks for unnecessary symbol conversions.
-  Enabled: false
+  Enabled: true
   VersionAdded: '1.9'
   EnforcedStyle: strict
   SupportedStyles:


### PR DESCRIPTION
## What

This enables the [`Lint/SymbolConversion` cop](https://docs.rubocop.org/rubocop/cops_lint.html#lintsymbolconversion).

## Why

A common mistake in Ruby is to assume that wrapping `Symbol` `Hash` keys in quotes makes the `Hash` use `String` keys.

<table>
<thead><tr><th>Erroneous Usage</th><th>Intended Usage</th></tr></thead>
<tbody><tr><td>

```ruby
{
  "these":   1,
  "look":    2,
  "like":    3,
  "strings": 4,
  "but":     5,
  "are":     6,
  "symbols": 7,
}
```

</td><td>

```ruby
{
  "these"    => 1,
  "actually" => 2,
  "are"      => 3,
  "strings"  => 4,
  "and"      => 5,
  "not"      => 6,
  "symbols"  => 7,
}
```

</tr></tbody>
</table>

This cop enforces the use of the simplest version of a Symbol possible, as shown in these examples from the documentation

> ```ruby
> # bad
> 'string'.to_sym
> :symbol.to_sym
> 'underscored_string'.to_sym
> :'underscored_symbol'
> 'hyphenated-string'.to_sym
> 
> # good
> :string
> :symbol
> :underscored_string
> :underscored_symbol
> :'hyphenated-string'
> ```

This will incidentally catch Symbol Hash keys that are needlessly quoted, helping to prevent this mistake. The correction of other Symbols is a bonus.