### PR TITLE
Allow shadowing outer local variables

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -249,6 +249,9 @@ Lint/SendWithMixinArgument:
 Lint/ShadowedArgument:
   Enabled: false
 
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
 Lint/StructNewOverride:
   Enabled: false
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1481,7 +1481,7 @@ Lint/ShadowedException:
 Lint/ShadowingOuterLocalVariable:
   Description: Do not use the same name as outer local variable for block arguments
     or block local variables.
-  Enabled: true
+  Enabled: false
   VersionAdded: '0.9'
 Lint/StructNewOverride:
   Description: Disallow overriding the `Struct` built-in methods via `Struct.new`.


### PR DESCRIPTION
This lint was created to replace a warning that Ruby removed.

The warning existed because there was a change in behavior introduced in version 1.9. Previously reusing a local variable resulted in the outer variable taking the value of the inner variable. After that change, there is shadowing, so they added a warning, which was finally removed in 2.6: https://bugs.ruby-lang.org/issues/12490.

But like mentioned in that issue, I think it's fair to shadow variables, like in the example:

```ruby
user = users.find { |user| user.parent == parent }
```
