### PR TITLE
Use `consistent_comma` in literals instead of `comma`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -640,10 +640,10 @@ Style/TrailingCommaInArguments:
   Enabled: false
 
 Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma
 
 Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma
 
 Style/TrailingMethodEndStatement:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3493,7 +3493,7 @@ Style/TrailingCommaInArrayLiteral:
   StyleGuide: "#no-trailing-array-commas"
   Enabled: true
   VersionAdded: '0.53'
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
@@ -3506,7 +3506,7 @@ Style/TrailingCommaInBlockArgs:
 Style/TrailingCommaInHashLiteral:
   Description: Checks for trailing comma in hash literals.
   Enabled: true
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma
   SupportedStylesForMultiline:
   - comma
   - consistent_comma


### PR DESCRIPTION
Both settings enforce the use of trailing commas, but they behave differently when multiple items are on one line.

<table>
<thead><tr><th><code>comma</code></th><th><code>consistent_comma</code></th></tr></thead>
<tbody><tr><td>

```ruby
[
  foo,
  bar,
]
```

</td><td>

```ruby
[
  foo,
  bar,
]
```

</td><tr></tr><td>

```ruby
[
  one, three, five, seven, nine,
  two, four, six, eight
]                    # ^
```

</td><td>

```ruby
[
  one, three, five, seven, nine,
  two, four, six, eight,
]                    # ^
```

</td><tr>
</tbody>
</table>

Sometimes it makes sense to group certain items if they are related, and it seems weird that doing that would disable the trailing comma convention.

Real world use case:

```ruby
# config/initializers/filter_parameter_logging.rb
Rails.application.config.filter_parameters += [
  :password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
  # These exist on Twilio resources and can contain anything including PII, so we must treat them as unsafe.
  /task_?attributes/i, /worker_?attributes/i
]
```

The currently enforced style (`comma`) requires no trailing comma on that last line, which is inconsistent with the style we have otherwise. `consistent_comma` consistently enforces trailing commas.