### PR TITLE
Disable cops clashing with Sorbet requirements

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -279,6 +279,9 @@ Lint/UnmodifiedReduceAccumulator:
 Lint/UnreachableLoop:
   Enabled: false
 
+Lint/UnusedMethodArgument:
+  Enabled: false
+
 Lint/UriEscapeUnescape:
   Enabled: false
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1582,7 +1582,7 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Description: Checks for unused method arguments.
   StyleGuide: "#underscore-unused-vars"
-  Enabled: true
+  Enabled: false
   VersionAdded: '0.21'
   VersionChanged: '0.81'
   AllowUnusedKeywordArguments: false


### PR DESCRIPTION
With Sorbet, parameters and blocks should always match between the introduction and the override of a method.

Examples [here](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Parent%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20params(a%3A%20Integer%2C%20b%3A%20String%2C%20block%3A%20T.proc.void).void%20%7D%0A%20%20def%20foo(a%2C%20b%2C%20%26block)%3B%20end%0Aend%0A%0Aclass%20ChildBad%20%3C%20Parent%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20override.params(a%3A%20Integer).void%20%7D%0A%20%20def%20foo(a)%0A%20%20end%0Aend%0A%0Aclass%20ChildGood1%20%3C%20Parent%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20override.params(a%3A%20Integer%2C%20b%3A%20String%2C%20block%3A%20T.proc.void).void%20%7D%0A%20%20def%20foo(a%2C%20b%2C%20%26block)%0A%20%20end%0Aend%0A%0Aclass%20ChildGood2%20%3C%20Parent%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20override.params(a%3A%20Integer%2C%20_b%3A%20String%2C%20_block%3A%20T.proc.void).void%20%7D%0A%20%20def%20foo(a%2C%20_b%2C%20%26_block)%0A%20%20end%0Aend):

```ruby
class Parent
  extend T::Sig

  sig { params(a: Integer, b: String, block: T.proc.void).void }
  def foo(a, b, &block); end
end

class ChildBad < Parent
  extend T::Sig

  sig { override.params(a: Integer).void }
  def foo(a)
# ^^^^^^^^^^ error: Override of method Parent#foo must accept at least 2 positional arguments
# ^^^^^^^^^^ error: Override of method Parent#foo must explicitly name a block argument
  end
end
```

This clashes with the cops `Lint/UnusedBlockArgument` and `Lint/UnusedMethodArgument`.

The names can be changed so we can still prefix them with `_`:

```rb
class ChildGood < Parent
  extend T::Sig

  sig { override.params(a: Integer, _b: String, _block: T.proc.void).void }
  def foo(a, _b, &_block)
  end
end
```

Closes https://github.com/Shopify/sorbet-issues/issues/346.