### PR TITLE
Enable and configure Naming/InclusiveLanguage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-shopify (2.1.0)
-      rubocop (~> 1.17)
+      rubocop (~> 1.18)
 
 GEM
   remote: https://rubygems.org/

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
     "allowed_push_host" => "https://rubygems.org",
   }
 
-  s.add_dependency("rubocop", "~> 1.17")
+  s.add_dependency("rubocop", "~> 1.18")
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -340,7 +340,17 @@ Naming/HeredocDelimiterNaming:
   Enabled: false
 
 Naming/InclusiveLanguage:
-  Enabled: false
+  Enabled: true
+  FlaggedTerms:
+    master:
+      Suggestions:
+        - main
+        - primary
+        - leader
+      AllowedRegex:
+        - !ruby/regexp '/master[_\s\.]key/' # Rails master key
+        - 'blob/master/'
+        - 'origin/master'
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1857,7 +1857,7 @@ Naming/HeredocDelimiterNaming:
   - !ruby/regexp /(^|\s)(EO[A-Z]{1}|END)(\s|$)/
 Naming/InclusiveLanguage:
   Description: Recommend the use of inclusive language instead of problematic terms.
-  Enabled: false
+  Enabled: true
   VersionAdded: '1.18'
   CheckIdentifiers: true
   CheckConstants: true
@@ -1882,6 +1882,15 @@ Naming/InclusiveLanguage:
       - replica
       - secondary
       - follower
+    master:
+      Suggestions:
+      - main
+      - primary
+      - leader
+      AllowedRegex:
+      - !ruby/regexp /master[_\s\.]key/
+      - blob/master/
+      - origin/master
 Naming/MemoizedInstanceVariableName:
   Description: Memoized method name should match memo instance variable name.
   Enabled: false


### PR DESCRIPTION
This is a follow-up to https://github.com/Shopify/shopify-cops/issues/204.

A generic [Naming/InclusiveLanguage](https://github.com/rubocop/rubocop/pull/9842) cop has been included with the recent `v1.18.x` release of Rubocop. 

The cop can be configured to search in various places for problematic terms and suggest more inclusive language.

This pull request proposes that we enable the cop and explicitly set all configuration. I don't recommend relying on defaults for this cop because I expect they may continue to change in rubocop. A day after the initial release `master` was removed from the flagged terms, and `CheckStrings` was flipped to false.

I'm hoping that this pull request can be used to discuss the specifics of the configuration that we want to enable, especially with respect to the flagged terms.

Note: I'll update the config dump once there is agreement on the configuration.
