### PR TITLE
Allow Trailing Whitespace in HEREDOC

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -108,6 +108,10 @@ Layout/SpaceBeforeBrackets:
 Layout/SpaceInLambdaLiteral:
   Enabled: false
 
+Layout/TrailingWhitespace:
+  Enabled: true
+  AllowInHeredoc: true
+
 Lint/AmbiguousAssignment:
   Enabled: false
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -951,7 +951,7 @@ Layout/TrailingWhitespace:
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '1.0'
-  AllowInHeredoc: false
+  AllowInHeredoc: true
 Lint/AmbiguousAssignment:
   Description: Checks for mistyped shorthand assignments.
   Enabled: false


### PR DESCRIPTION
When implementing this rule in Shopify/Shopify I found that it breaks a lot of assumptions with HEREDOC and signficantly reduces the readability of code.

This is the current `AllowInHeredoc: false` PR: https://github.com/Shopify/shopify/pull/305742/

You can see that it adds `#{"      "}` type changes in heredoc, but also auto-corrects the HEREDOC to be further indented (I'm not sure _why_) and that breaks a lot of test assumptions.

Here is the same PR but with `AllowInHeredoc: true`: https://github.com/Shopify/shopify/pull/305743

You can see this is fixing what I would expect 99%+ of developers would want fixed. And doesn't break tests/behaviour