### PR TITLE
Add the mastercard brand to AllowedRegex of Naming/InclusiveLanguage

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -351,6 +351,7 @@ Naming/InclusiveLanguage:
         - !ruby/regexp '/master[_\s\.]key/' # Rails master key
         - 'blob/master/'
         - 'origin/master'
+        - 'mastercard'
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1891,6 +1891,7 @@ Naming/InclusiveLanguage:
       - !ruby/regexp /master[_\s\.]key/
       - blob/master/
       - origin/master
+      - mastercard
 Naming/MemoizedInstanceVariableName:
   Description: Memoized method name should match memo instance variable name.
   Enabled: false


### PR DESCRIPTION
Mastercard is a brand name used throughout our code.
https://grok.shopifycloud.com/results?q=mastercard

