### PR TITLE
Enable `Style/ExplicitBlockArgument` cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -468,7 +468,7 @@ Style/ExpandPathArguments:
   Enabled: false
 
 Style/ExplicitBlockArgument:
-  Enabled: false
+  Enabled: true
 
 Style/ExponentialNotation:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -2502,7 +2502,7 @@ Style/ExplicitBlockArgument:
   Description: Consider using explicit block argument to avoid writing block literal
     that just passes its arguments to another block.
   StyleGuide: "#block-argument"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.89'
   VersionChanged: '1.8'
 Style/ExponentialNotation:


### PR DESCRIPTION
The code is disabled by default because in some cases it could change the block arity which might fail if the block is
actually a lambda.

However I enabled it on [Rails](https://github.com/rails/rails/pull/43170) and [shopify-core](https://github.com/Shopify/shopify/pull/310915) and it went just fine.

Since this cop is beneficial for production performance and for trimming CI backtraces a bit, I think we should enable it.