### PR TITLE
Enable Gemspec cops

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -10,18 +10,9 @@ Bundler/OrderedGems:
   Enabled: false
 
 Gemspec/DateAssignment:
-  Enabled: false
-
-Gemspec/DuplicatedAssignment:
-  Enabled: false
-
-Gemspec/OrderedDependencies:
-  Enabled: false
+  Enabled: true
 
 Gemspec/RequiredRubyVersion:
-  Enabled: false
-
-Gemspec/RubyVersionGlobalsUsage:
   Enabled: false
 
 Layout/ArgumentAlignment:

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -158,20 +158,20 @@ Bundler/OrderedGems:
 Gemspec/DateAssignment:
   Description: Checks that `date =` is not used in gemspec file, it is set automatically
     when the gem is packaged.
-  Enabled: false
+  Enabled: true
   VersionAdded: '1.10'
   Include:
   - "**/*.gemspec"
 Gemspec/DuplicatedAssignment:
   Description: An attribute assignment method calls should be listed only once in
     a gemspec.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.52'
   Include:
   - "**/*.gemspec"
 Gemspec/OrderedDependencies:
   Description: Dependencies in the gemspec should be alphabetically sorted.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.51'
   TreatCommentsAsGroupSeparators: true
   ConsiderPunctuation: false
@@ -188,7 +188,7 @@ Gemspec/RequiredRubyVersion:
 Gemspec/RubyVersionGlobalsUsage:
   Description: Checks usage of RUBY_VERSION in gemspec.
   StyleGuide: "#no-ruby-version-in-the-gemspec"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.72'
   Include:
   - "**/*.gemspec"


### PR DESCRIPTION
This is the first of a series of proposals intended to revisit the cops we are disabling for each department and see if they should be enforced. The idea is to see the value some disabled cops might bring to our users compared to the effort required to apply corrections to those.

This PR enables four cops from the `Gemspec` department:

* `date` assignment should not be set in gemspec files.
* Gemspec files should not have duplicate assignments.
* Dependencies should be listed in alphabetical order in gemspec files.
* The usage of the `RUBY_VERSION` constant is not allowed in gemspec files.

More information about these cops can be seen at https://docs.rubocop.org/rubocop/cops_gemspec.html

If this proposal is approved these cops will be enabled in the next minor version of `rubocop-shopify`.