### PR TITLE
Enable Layout cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 ## Table of Contents
 
 * [General](#general)
-* [Formatting](#formatting)
+* [Layout](#layout)
 * [Syntax](#syntax)
 * [Naming](#naming)
 * [Classes and Modules](#classes-and-modules)
@@ -88,7 +88,7 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 
 * Avoid more than three levels of block nesting.
 
-## Formatting
+## Layout
 
 * Use `UTF-8` as the source file encoding.
 
@@ -107,6 +107,26 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 * Avoid space after the `!` operator.
 
 * Avoid space inside range literals.
+
+* Avoid space around method call operators.
+
+  ~~~ruby
+  # bad
+  foo . bar
+
+  # good
+  foo.bar
+  ~~~
+
+* Avoid space in lambda literals.
+
+  ~~~ruby
+  # bad
+  a = -> (x, y) { x + y }
+
+  # good
+  a = ->(x, y) { x + y }
+  ~~~
 
 * Indent `when` as deep as the `case` line.
 
@@ -244,6 +264,88 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
     arg_1,
     arg_2,
   )
+  ~~~
+
+* Separate magic comments from code and documentation with a blank line.
+
+  ~~~ruby
+  # good
+  # frozen_string_literal: true
+
+  # Some documentation for Person
+  class Person
+    # Some code
+  end
+
+  # bad
+  # frozen_string_literal: true
+  # Some documentation for Person
+  class Person
+    # Some code
+  end
+  ~~~
+
+* Use empty lines around attribute accessor.
+
+  ~~~ruby
+  # bad
+  class Foo
+    attr_reader :foo
+    def foo
+      # do something...
+    end
+  end
+
+  # good
+  class Foo
+    attr_reader :foo
+
+    def foo
+      # do something...
+    end
+  end
+  ~~~
+
+* Avoid empty lines around method, class, module, and block bodies.
+
+  ~~~ruby
+  # bad
+  class Foo
+
+    def foo
+
+      begin
+
+        do_something do
+
+          something
+
+        end
+
+      rescue
+
+        something
+
+      end
+
+      true
+
+    end
+
+  end
+
+  # good
+  class Foo
+    def foo
+      begin
+        do_something do
+          something
+        end
+      rescue
+        something
+      end
+    end
+  end
   ~~~
 
 ## Syntax
@@ -1045,6 +1147,48 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
     end
   END
   # => "def test\n  some_method\n  other_method\nend\n"
+  ~~~
+
+* Indent heredoc contents and closing according to its opening.
+
+  ~~~ruby
+  # bad
+  class Foo
+    def bar
+      <<~SQL
+        'Hi'
+    SQL
+    end
+  end
+
+  # good
+  class Foo
+    def bar
+      <<~SQL
+        'Hi'
+      SQL
+    end
+  end
+
+  # bad
+
+  # heredoc contents is before closing heredoc.
+  foo arg,
+      <<~EOS
+    Hi
+      EOS
+
+  # good
+  foo arg,
+      <<~EOS
+    Hi
+  EOS
+
+  # good
+  foo arg,
+    <<~EOS
+      Hi
+    EOS
   ~~~
 
 ## Regular Expressions

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -21,28 +21,7 @@ Layout/ArgumentAlignment:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/ClosingHeredocIndentation:
-  Enabled: false
-
-Layout/EmptyComment:
-  Enabled: false
-
 Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
-Layout/EmptyLineAfterMagicComment:
-  Enabled: false
-
-Layout/EmptyLinesAroundArguments:
-  Enabled: false
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: false
-
-Layout/EmptyLinesAroundBeginBody:
-  Enabled: false
-
-Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: false
 
 Layout/EndAlignment:
@@ -57,17 +36,12 @@ Layout/FirstArrayElementIndentation:
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
-Layout/FirstParameterIndentation:
-  Enabled: false
-
 Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: ignore_implicit
 
-Layout/LeadingEmptyLines:
-  Enabled: false
-
 Layout/LineEndStringConcatenationIndentation:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: indented
 
 Layout/LineLength:
   IgnoreCopDirectives: false
@@ -79,19 +53,13 @@ Layout/MultilineMethodCallIndentation:
   IndentationWidth: 2
 
 Layout/MultilineOperationIndentation:
-  Enabled: false
+  EnforcedStyle: indented
 
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: false
-
 Layout/SpaceBeforeBrackets:
-  Enabled: false
-
-Layout/SpaceInLambdaLiteral:
-  Enabled: false
+  Enabled: true
 
 Lint/AmbiguousAssignment:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -285,7 +285,7 @@ Layout/ClassStructure:
   - private_methods
 Layout/ClosingHeredocIndentation:
   Description: Checks the indentation of here document closings.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.57'
 Layout/ClosingParenthesisIndentation:
   Description: Checks the indentation of hanging closing parentheses.
@@ -326,7 +326,7 @@ Layout/ElseAlignment:
   VersionAdded: '0.49'
 Layout/EmptyComment:
   Description: Checks empty comment.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.53'
   AllowBorderComment: true
   AllowMarginComment: true
@@ -338,7 +338,7 @@ Layout/EmptyLineAfterGuardClause:
 Layout/EmptyLineAfterMagicComment:
   Description: Add an empty line after magic comments to separate them from code.
   StyleGuide: "#separate-magic-comments-from-code"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
 Layout/EmptyLineAfterMultilineCondition:
   Description: Enforces empty line after multiline condition.
@@ -375,12 +375,12 @@ Layout/EmptyLinesAroundAccessModifier:
   - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 Layout/EmptyLinesAroundArguments:
   Description: Keeps track of empty lines around method arguments.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.52'
 Layout/EmptyLinesAroundAttributeAccessor:
   Description: Keep blank lines around attribute accessors.
   StyleGuide: "#empty-lines-around-attribute-accessor"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.83'
   VersionChanged: '0.84'
   AllowAliasSyntax: true
@@ -392,7 +392,7 @@ Layout/EmptyLinesAroundAttributeAccessor:
 Layout/EmptyLinesAroundBeginBody:
   Description: Keeps track of empty lines around begin-end bodies.
   StyleGuide: "#empty-lines-around-bodies"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
 Layout/EmptyLinesAroundBlockBody:
   Description: Keeps track of empty lines around block bodies.
@@ -420,7 +420,7 @@ Layout/EmptyLinesAroundClassBody:
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Description: Keeps track of empty lines around exception handling keywords.
   StyleGuide: "#empty-lines-around-bodies"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
 Layout/EmptyLinesAroundMethodBody:
   Description: Keeps track of empty lines around method bodies.
@@ -519,7 +519,7 @@ Layout/FirstMethodParameterLineBreak:
   VersionAdded: '0.49'
 Layout/FirstParameterIndentation:
   Description: Checks the indentation of the first parameter in a method definition.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: consistent
@@ -605,15 +605,15 @@ Layout/LeadingCommentSpace:
   AllowGemfileRubyComment: false
 Layout/LeadingEmptyLines:
   Description: Check for unnecessary blank lines at the beginning of a file.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.57'
   VersionChanged: '0.77'
 Layout/LineEndStringConcatenationIndentation:
   Description: Checks the indentation of the next line after a line that ends with
     a string literal and a backslash.
-  Enabled: false
+  Enabled: true
   VersionAdded: '1.18'
-  EnforcedStyle: aligned
+  EnforcedStyle: indented
   SupportedStyles:
   - aligned
   - indented
@@ -721,9 +721,9 @@ Layout/MultilineMethodDefinitionBraceLayout:
   - same_line
 Layout/MultilineOperationIndentation:
   Description: Checks indentation of binary operations that span more than one line.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
-  EnforcedStyle: aligned
+  EnforcedStyle: indented
   SupportedStyles:
   - aligned
   - indented
@@ -804,7 +804,7 @@ Layout/SpaceAroundKeyword:
   VersionAdded: '0.49'
 Layout/SpaceAroundMethodCallOperator:
   Description: Checks method call operators to not have spaces around them.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.82'
 Layout/SpaceAroundOperators:
   Description: Use a single space around operators.
@@ -832,7 +832,7 @@ Layout/SpaceBeforeBlockBraces:
 Layout/SpaceBeforeBrackets:
   Description: Checks for receiver with a space before the opening brackets.
   StyleGuide: "#space-in-brackets-access"
-  Enabled: false
+  Enabled: true
   VersionAdded: '1.7'
 Layout/SpaceBeforeComma:
   Description: No spaces before commas.
@@ -854,7 +854,7 @@ Layout/SpaceBeforeSemicolon:
   VersionAdded: '0.49'
 Layout/SpaceInLambdaLiteral:
   Description: Checks for spaces in lambda literals.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: require_no_space
   SupportedStyles:


### PR DESCRIPTION
This is the third of a series of proposals intended to revisit the cops we are disabling for each department and see if they should be enforced. The idea is to see the value some disabled cops might bring to our users compared to the effort required to apply corrections to those.

This PR enables four cops from the `Layout` department, and reflects these changes in the Style Guide under the "Layout
 section (formerly known as the "Formatting" section) for the cops that require clarification or examples. Even though this list is a bit long, these cops are autocorrectable and easy to adopt. Some of these are also just common sense like avoiding leading spaces in source files or empty comment lines.

* Heredocs must be indented (added example to the Style Guide).
* Empty comment lines should be avoided.
* There should be an empty line between magic comments and the rest of the code (added example to the Style Guide).
* Empty lines around arguments should be avoided.
* Attribute accessors should be surrounded by empty lines (added example to the Style Guide).
* There should not be empty lines around `begin` and exception capture keywords (added example to the Style Guide).
* The first parameter of a method call should be aligned according to the previous line (the rule already exists).
* Leading empty lines should be removed.
* String concatenation should be indented when spanning multiple lines.
* There shouldn't be spaces around the method call operator (added example to the Style Guide).
* There shouldn't be spaces in lambda literals (added example to the Style Guide).

More information about these cops can be seen at https://docs.rubocop.org/rubocop/cops_layout.html

If this proposal is approved these cops will be enabled in the next minor version of `rubocop-shopify`.