### PR TITLE
Regex improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,7 +1199,8 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
   string["text"]
   ~~~
 
-* Use non-capturing groups when you don't use the captured result.
+* Use non-capturing groups when you don't use the captured result inside the
+  regular expression.
 
   ~~~ ruby
   # bad
@@ -1207,6 +1208,16 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 
   # good
   /(?:first|second)/
+  ~~~
+
+* Use `Regexp#match?` when you don't use the captured result in Ruby.
+
+  ~~~ ruby
+  # bad
+  /(first|second)/.match(string)
+
+  # good
+  /(?:first|second)/.match?(string)
   ~~~
 
 * Prefer `Regexp#match` over Perl-legacy variables to capture group matches.

--- a/README.md
+++ b/README.md
@@ -1235,6 +1235,10 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
   ~~~
 
 * Prefer `\A` and `\z` over `^` and `$` when matching strings from start to end.
+  Incomplete matching of strings is a commonly made mistake when validating
+  strings and can lead to security vulnerabilities. For more details see the
+  [Rails security guide](https://guides.rubyonrails.org/security.html#regular-expressions)
+  and [CWE-625: Permissive Regular Expression](https://cwe.mitre.org/data/definitions/625.html).
 
   ~~~ ruby
   string = "some injection\nusername"


### PR DESCRIPTION
Regex anchoring was missing an IMO pretty important _why_ this is preferred, so added that.

For the `match?` addition I considered merging it with the non-capturing group recommendation, but figured both recommendations could stand on their own: one could be using both capturing and non-capturing groups in the same regular expression.