### PR TITLE
Enable `Layout/EmptyLineAfterGuardClause` cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -25,7 +25,7 @@ Layout/CaseIndentation:
   EnforcedStyle: end
 
 Layout/EmptyLineAfterGuardClause:
-  Enabled: false
+  Enabled: true
 
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -346,7 +346,7 @@ Layout/EmptyComment:
   AllowMarginComment: true
 Layout/EmptyLineAfterGuardClause:
   Description: Add empty line after guard clause.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.56'
   VersionChanged: '0.59'
 Layout/EmptyLineAfterMagicComment:


### PR DESCRIPTION
This enables the [`Layout/EmptyLineAfterGuardClause`](https://docs.rubocop.org/rubocop/cops_layout.html#layoutemptylineafterguardclause) cop, which is **autocorrectable**.

From the documentation

> ```ruby
> # bad
> def foo
>   return if need_return?
>   bar
> end
> 
> # good
> def foo
>   return if need_return?
> 
>   bar
> end
> 
> # good
> def foo
>   return if something?
>   return if something_different?
> 
>   bar
> end
> 
> # also good
> def foo
>   if something?
>     do_something
>     return if need_return?
>   end
> end
> ```