### PR TITLE
Stop disabling Style/MutableConstant

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -549,6 +549,9 @@ Style/MultilineWhenThen:
 Style/MultipleComparison:
   Enabled: false
 
+Style/MutableConstant:
+  EnforcedStyle: literals
+
 Style/NegatedIfElseCondition:
   Enabled: false
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3014,7 +3014,7 @@ Style/MultipleComparison:
   AllowMethodComparison: true
 Style/MutableConstant:
   Description: Do not assign mutable objects to constants.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.34'
   VersionChanged: '1.8'
   SafeAutoCorrect: false


### PR DESCRIPTION
I couldn't find any discussion about this cop, but I believe it's a positive one.

First there's the correctness argument. If a constant is mutable is it really a constant?

Then there's a performance argument. Hashes unless frozen are mutated uppon iteration
(their internal `iter_level` attribute is incremented). This cause constant hashes that
are in a clean CoW region to invalidate the entire 4kiB memory page.

cc @rafaelfranca as I think you have some strong opinions on this one.