### PR TITLE
Allow 'webmaster' for Naming/InclusiveLanguage

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -326,6 +326,7 @@ Naming/InclusiveLanguage:
         - 'blob/master/'
         - 'origin/master'
         - 'mastercard'
+        - 'webmaster'
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1971,6 +1971,7 @@ Naming/InclusiveLanguage:
       - blob/master/
       - origin/master
       - mastercard
+      - webmaster
 Naming/MemoizedInstanceVariableName:
   Description: Memoized method name should match memo instance variable name.
   Enabled: false


### PR DESCRIPTION
I'm working through inclusive language violations in Shopify and have come across a number of the `master` pattern triggering on usages of `webmaster`. But that is triggering on things like references to "Webmaster tools" and URLs or emails containing "webmaster". All things we don't control, linking out or using external services.

I'm not sure about this specific term. But I've gone through some references and have found nothing talking about "webmaster". So I'm arguing to allow it as we do for "mastercard".

Some docs:
* https://github.com/ietf/terminology
* https://datatracker.ietf.org/doc/html/draft-knodel-terminology-08