### PR TITLE
Disable EnforcedShorthandSyntax in Style/HashSyntax

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -484,6 +484,9 @@ Style/HashExcept:
 Style/HashLikeCase:
   Enabled: false
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either
+
 Style/HashTransformKeys:
   Enabled: false
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -2718,7 +2718,7 @@ Style/HashSyntax:
   - hash_rockets
   - no_mixed_keys
   - ruby19_no_mixed_keys
-  EnforcedShorthandSyntax: always
+  EnforcedShorthandSyntax: either
   SupportedShorthandSyntax:
   - always
   - never


### PR DESCRIPTION
We should not be forcing the shorthand syntax because of a few reasons:

1. That syntax doesn't always yields the best/clear code. It has
surprising behavior specially with method calls using the key names.
2. Ruby 3.1 shorthand syntax is still not supported by Sorbet.

We can fix 2, but not 1, so it is better to just allow people to chose
when to use the shorthand syntax in the context that makes sense.