### PR TITLE
Release version 2.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-shopify (2.5.0)
-      rubocop (~> 1.24)
+      rubocop (~> 1.25)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,7 @@ GEM
     method_source (1.0.0)
     minitest (5.15.0)
     parallel (1.21.0)
-    parser (3.1.0.0)
+    parser (3.1.1.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -24,7 +24,7 @@ GEM
       pry (~> 0.13.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.0)
+    regexp_parser (2.2.1)
     rexml (3.2.5)
     rubocop (1.25.1)
       parallel (~> 1.10)
@@ -35,8 +35,8 @@ GEM
       rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
+    rubocop-ast (1.16.0)
+      parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (2.4.0)
+    rubocop-shopify (2.5.0)
       rubocop (~> 1.24)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
     "allowed_push_host" => "https://rubygems.org",
   }
 
-  s.add_dependency("rubocop", "~> 1.24")
+  s.add_dependency("rubocop", "~> 1.25")
 end

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "2.4.0"
+  s.version     = "2.5.0"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Shopify's style guide for Ruby."


### PR DESCRIPTION
We need to bump the version number to get Shipit to publish the gem. The [tag](https://github.com/Shopify/ruby-style-guide/tree/v2.5.0) and [release](https://github.com/Shopify/ruby-style-guide/releases/tag/v2.5.0) already exist, and therefore won’t point to this commit, but I don’t think that will cause any real problems.