### PR TITLE
Dynamically choose `{Allowed,Ignored}Patterns` config key for Rubocop version

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineEndStringConcatenationIndentation:
 
 Layout/LineLength:
   IgnoreCopDirectives: false
-  IgnoredPatterns:
+  <%= Gem.loaded_specs['rubocop'].version >= Gem::Version.new('1.28') ? 'AllowedPatterns' : 'IgnoredPatterns' %>:
   - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
 
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
`IgnoredPatterns` was deprecated in Rubocop 1.28 in favour of `AllowedPatterns`.

This approach allows us to fix the deprecation warning without requiring consumers to bump Rubocop.

Closes #377