### PR TITLE
Enforce Multiline Method calls, Arrays, and Hashes to use one line per element

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,40 +272,61 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 
   ~~~ ruby
   # bad
-  
+
   method(arg_1, arg_2,
     arg_3
   )
-  
+
   [
     value_1, value_2,
     value_3,
   ]
-  
+
   {
     key1: value_1,
     key2: value_2, key3: value_3,
   }
 
   # good
-  
+
   method(
     arg_1,
     arg_2,
     arg_3,
   )
-  
+
   [
     value_1,
     value_2,
     value_3,
   ]
-  
+
   {
     key1: value_1,
     key2: value_2,
     key3: value_3,
   }
+
+  # good (special cases)
+
+  # Single argument method call
+  method({
+    foo: bar,
+  })
+
+  # Last argument, itself is multiline
+  class User
+    after_save :method, if: -> {
+      do_some_checks
+    }
+  end
+
+  # Single value array
+  errors = [{
+    error_code: 1234,
+    error_message: "This is an error",
+  }]
+
   ~~~
 
 * Separate magic comments from code and documentation with a blank line.

--- a/README.md
+++ b/README.md
@@ -267,6 +267,47 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
   )
   ~~~
 
+* Place each element/argument on a new line when wrapping a method call, hash, or array
+  on multiple lines.
+
+  ~~~ ruby
+  # bad
+  
+  method(arg_1, arg_2,
+    arg_3
+  )
+  
+  [
+    value_1, value_2,
+    value_3,
+  ]
+  
+  {
+    key1: value_1,
+    key2: value_2, key3: value_3,
+  }
+
+  # good
+  
+  method(
+    arg_1,
+    arg_2,
+    arg_3,
+  )
+  
+  [
+    value_1,
+    value_2,
+    value_3,
+  ]
+  
+  {
+    key1: value_1,
+    key2: value_2,
+    key3: value_3,
+  }
+  ~~~
+
 * Separate magic comments from code and documentation with a blank line.
 
   ~~~ruby

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -35,6 +35,7 @@ Layout/FirstArrayElementIndentation:
 
 Layout/FirstArrayElementLineBreak:
   Enabled: true
+  AllowMultilineFinalElement: true
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
@@ -44,6 +45,7 @@ Layout/FirstHashElementLineBreak:
 
 Layout/FirstMethodArgumentLineBreak:
   Enabled: true
+  AllowMultilineFinalElement: true
 
 Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: ignore_implicit
@@ -65,12 +67,14 @@ Layout/LineLength:
 
 Layout/MultilineArrayLineBreaks:
   Enabled: true
+  AllowMultilineFinalElement: true
 
 Layout/MultilineHashKeyLineBreaks:
   Enabled: true
 
 Layout/MultilineMethodArgumentLineBreaks:
   Enabled: true
+  AllowMultilineFinalElement: true
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -33,8 +33,17 @@ Layout/FirstArgumentIndentation:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
 
 Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: ignore_implicit

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -28,7 +28,7 @@ Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
 Layout/FirstArgumentIndentation:
-  Enabled: false
+  EnforcedStyle: consistent
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -54,6 +54,15 @@ Layout/LineLength:
   AllowedPatterns:
   - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
 
+Layout/MultilineArrayLineBreaks:
+  Enabled: true
+
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
   IndentationWidth: 2

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -715,7 +715,7 @@ Layout/MultilineArrayBraceLayout:
 Layout/MultilineArrayLineBreaks:
   Description: Checks that each item in a multi-line array literal starts on a separate
     line.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.67'
   AllowMultilineFinalElement: false
 Layout/MultilineAssignmentLayout:
@@ -751,13 +751,13 @@ Layout/MultilineHashBraceLayout:
 Layout/MultilineHashKeyLineBreaks:
   Description: Checks that each item in a multi-line hash literal starts on a separate
     line.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.67'
   AllowMultilineFinalElement: false
 Layout/MultilineMethodArgumentLineBreaks:
   Description: Checks that each argument in a multi-line method call starts on a separate
     line.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.67'
   AllowMultilineFinalElement: false
 Layout/MultilineMethodCallBraceLayout:

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -533,7 +533,7 @@ Layout/FirstArrayElementLineBreak:
   Description: Checks for a line break before the first element in a multi-line array.
   Enabled: true
   VersionAdded: '0.49'
-  AllowMultilineFinalElement: false
+  AllowMultilineFinalElement: true
 Layout/FirstHashElementIndentation:
   Description: Checks the indentation of the first key in a hash literal.
   Enabled: true
@@ -555,7 +555,7 @@ Layout/FirstMethodArgumentLineBreak:
     call.
   Enabled: true
   VersionAdded: '0.49'
-  AllowMultilineFinalElement: false
+  AllowMultilineFinalElement: true
 Layout/FirstMethodParameterLineBreak:
   Description: Checks for a line break before the first parameter in a multi-line
     method parameter definition.
@@ -717,7 +717,7 @@ Layout/MultilineArrayLineBreaks:
     line.
   Enabled: true
   VersionAdded: '0.67'
-  AllowMultilineFinalElement: false
+  AllowMultilineFinalElement: true
 Layout/MultilineAssignmentLayout:
   Description: Check for a newline after the assignment operator in multi-line assignments.
   StyleGuide: "#indent-conditional-assignment"
@@ -759,7 +759,7 @@ Layout/MultilineMethodArgumentLineBreaks:
     line.
   Enabled: true
   VersionAdded: '0.67'
-  AllowMultilineFinalElement: false
+  AllowMultilineFinalElement: true
 Layout/MultilineMethodCallBraceLayout:
   Description: Checks that the closing brace in a method call is either on the same
     line as the last method argument, or a new line.

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -531,7 +531,7 @@ Layout/FirstArrayElementIndentation:
   IndentationWidth:
 Layout/FirstArrayElementLineBreak:
   Description: Checks for a line break before the first element in a multi-line array.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
   AllowMultilineFinalElement: false
 Layout/FirstHashElementIndentation:
@@ -547,13 +547,13 @@ Layout/FirstHashElementIndentation:
   IndentationWidth:
 Layout/FirstHashElementLineBreak:
   Description: Checks for a line break before the first element in a multi-line hash.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
   AllowMultilineFinalElement: false
 Layout/FirstMethodArgumentLineBreak:
   Description: Checks for a line break before the first argument in a multi-line method
     call.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.49'
   AllowMultilineFinalElement: false
 Layout/FirstMethodParameterLineBreak:

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -508,10 +508,10 @@ Layout/ExtraSpacing:
   ForceEqualSignAlignment: false
 Layout/FirstArgumentIndentation:
   Description: Checks the indentation of the first argument in a method call.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.68'
   VersionChanged: '0.77'
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  EnforcedStyle: consistent
   SupportedStyles:
   - consistent
   - consistent_relative_to_receiver


### PR DESCRIPTION
This might be a personal pet peeve of mine, but I find all the examples inside the `# bad` to be hard to read, and even lead me to simply not realize that one of the elements is here at all on more complex cases.

Adding the rules on this PR will autocorrect all those cases to use one line per argument and/or element, leading to a much better readability!

Those [are actually recommended](https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength) when using `Layout/LineLength`, and it does seems to be where I see the most of cases of "autocorrect gone wrong".

### bad (good before this Change)
```ruby
foo(
a,
b,
c,
)

foo(a, b,
  c)

foo(a,
  b,
  c)

{
  a: 1, b: 2,
  c: 3,
}

{ a: 1,
  b: 2,
  c: 3, }

[
  a, b,
  c,
]

[a,
  b,
  c,]
```
### Good (and enforced now)
```ruby
foo(
  a,
  b,
  c
)

foo(
  a,
  b,
  c
)

foo(a, b, c)

{
  a: 1,
  b: 2,
  c: 3,
}

{ a: 1, b: 2, c: 3 }

[
  a,
  b,
  c,
]

[a, b, c]
```

### Good (Exceptions, not affected by changes)
```ruby
# Multiline last argument
after_commit :do_something, if: -> {
  some_complex_logic
}

# Single argument call
foo({
  bar: bat,
})

# Single element array
errors = [{
  error: "this_is_bad",
  details: "This is not something good?",
}]
```

#### Missing pieces

Method declarations are not included, I played around with adding `Layout/FirstMethodParameterLineBreak`, while it does make it a little better, it does not forces arguments to go in individual lines, unless I'm missing something Rubocop seems to be lacking the required `Layout/MultilineMethodParameterLineBreaks` rule for this.
Because of that, I decided no to touch method declarations at all for now.