### PR TITLE
Skip config tests on minimum Rubocop version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,3 +28,5 @@ jobs:
       run: bundle info rubocop | head -1
     - name: RuboCop and Tests
       run: bundle exec rake
+      env:
+        CHECKING_RUBOCOP_VERSION_COMPATIBILITY: ${{ matrix.gemfile == 'gemfiles/minimum_rubocop.gemfile' }}

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -7,6 +7,8 @@ require "rake"
 
 class ConfigTest < Minitest::Test
   def test_config_is_unchanged
+    skip if checking_rubocop_version_compatibility?
+
     Rake.application.load_rakefile
 
     original_config = "test/fixtures/full_config.yml"
@@ -32,6 +34,8 @@ class ConfigTest < Minitest::Test
   end
 
   def test_config_has_no_redundant_entries
+    skip if checking_rubocop_version_compatibility?
+
     config = RuboCop::ConfigLoader.load_file("rubocop.yml")
     default_config = RuboCop::ConfigLoader.default_configuration
     redundant_config = Hash.new { |hash, key| hash[key] = {} }
@@ -56,5 +60,11 @@ class ConfigTest < Minitest::Test
     ERROR
 
     assert(redundant_config.empty?, error_message)
+  end
+
+  private
+
+  def checking_rubocop_version_compatibility?
+    ENV.fetch("CHECKING_RUBOCOP_VERSION_COMPATIBILITY", "") == "true"
   end
 end


### PR DESCRIPTION
While we want to ensure we're always compatible with the minimum Rubocop version we declare in our gemspec, the config checks are specific to the Rubocop version listed in `Gemfile.lock` because different Rubocop versions have different default config.

As such, we skip these tests when checking against the minimum Rubocop version.

Rubocop is still invoked against the repository's own code during these runs, which allows us to catch **incompatible** config (e.g. cops only available in new versions, deprecated config keys).