### PR TITLE
Move CODEOWNERS to Shopify/ruby-style-guide

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @volmer @rafaelfranca @Shopify/rails
+* @Shopify/ruby-style-guide


### PR DESCRIPTION
This team already existed, I just moved it under Shopify/rails. This might make it easier to give better permissions to contributors outside of the Rails Infra team.