### PR TITLE
Create LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015-2022 Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email    = "gems@shopify.com"
   s.homepage = "https://shopify.github.io/ruby-style-guide/"
 
-  s.files = ["rubocop.yml", "rubocop-cli.yml"]
+  s.files = ["rubocop.yml", "rubocop-cli.yml", "LICENSE.md"]
 
   s.metadata = {
     "source_code_uri" => "https://github.com/Shopify/ruby-style-guide/tree/v#{s.version}",


### PR DESCRIPTION
The gem was already licensed, but this repository wasn't. The code is licensed on MIT, so forks should include the copyright and the original license.