### PR TITLE
Activate MarkdownItAnchor plugin to get anchors

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,9 @@ const markdownIt = require('markdown-it')
 const markdownItAnchor = require('markdown-it-anchor')
 
 module.exports = function (eleventyConfig) {
-  const markdownLibrary = markdownIt().use(markdownItAnchor)
+  const markdownLibrary = markdownIt().use(markdownItAnchor, {
+    permalink: markdownItAnchor.permalink.headerLink()
+  })
   eleventyConfig.setLibrary('md', markdownLibrary)
 
   eleventyConfig.addPlugin(syntaxHighlight, {


### PR DESCRIPTION
The production version of this site doesn't have anchor links, even though headers all get unique IDs that could be used as anchors. It looks like we're already using the `MarkdownItAnchor` plugin, but it perhaps didn't get activated. 

This PR is just a small config change to activate anchor links using the [header link](https://github.com/valeriangalliat/markdown-it-anchor#header-link) style from the `MarkdownItAnchor` plugin.

Before: 
![image](https://user-images.githubusercontent.com/1622979/179032936-d5a18185-efe1-4d85-b8a7-b21f6030ffc6.png)

After: 
![image](https://user-images.githubusercontent.com/1622979/179033154-8abef9aa-fe6a-43b1-a764-4b2ff7322e02.png)
