### PR TITLE
Match rubocop-shopify with style guide recommendations

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -726,4 +726,5 @@ Style/YodaCondition:
 
 Style/ClassMethodsDefinitions:
   EnforcedStyle: self_class
+  Enabled: true
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -723,3 +723,7 @@ Style/WordArray:
 
 Style/YodaCondition:
   Enabled: false
+
+Style/ClassMethodsDefinitions:
+  EnforcedStyle: self_class
+

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -2370,7 +2370,7 @@ Style/ClassMethodsDefinitions:
   StyleGuide: "#def-self-class-methods"
   Enabled: false
   VersionAdded: '0.89'
-  EnforcedStyle: def_self
+  EnforcedStyle: self_class
   SupportedStyles:
   - def_self
   - self_class

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -2368,7 +2368,7 @@ Style/ClassMethodsDefinitions:
   Description: Enforces using `def self.method_name` or `class << self` to define
     class methods.
   StyleGuide: "#def-self-class-methods"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.89'
   EnforcedStyle: self_class
   SupportedStyles:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,10 @@ require "minitest/autorun"
 require "pry-byebug"
 
 module Warning
-  def self.warn(message)
-    raise message.to_s
+  class << self
+    def warn(message)
+      raise message.to_s
+    end
   end
 end
 Warning[:deprecated] = true


### PR DESCRIPTION
## Background

There is a discrepancy between shopify-rubocop and the Shopify Ruby Styleguide.

The [Ruby Styleguide says:]()

> Use a class << self block over def self. when defining class methods, and group them together within a single block.

( [pr for background](https://github.com/Shopify/ruby-style-guide/pull/29) )

There is an option to enable this in rubocop under `Style/ClassMethodsDefinitions` for `self_class`. Our current default does the opposite, with the `EnforcedStyle` being `def_self`.

This corrects the default.

## For Reviewers

This cop is currently set to `Enabled: false`. If we care enough about this to have an opinion in the styleguide should it be changed to `Enabled: true`? The `def self` vs `class << self` is a long-running question of preference so it might be nice to give clarity on this.

Signed-off-by: Nick Schwaderer <nick.schwaderer@shopify.com>