### PR TITLE
Prepare for 2.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (2.8.0)
+    rubocop-shopify (2.9.0)
       rubocop (~> 1.33)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "2.8.0"
+  s.version     = "2.9.0"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Shopify's style guide for Ruby."


### PR DESCRIPTION
This bumps the gem version ahead of releasing 2.9.0.

- [x] [Drafted release](https://github.com/Shopify/ruby-style-guide/releases/edit/untagged-3819623ef8ac24b7ceef)
     > * **Require Rubocop 1.33.0+**
     > * Enable [`Style/ClassMethodsDefinitions`](https://docs.rubocop.org/rubocop/cops_style.html#styleclassmethodsdefinitions) with style `self_class` in (https://github.com/Shopify/ruby-style-guide/pull/422)