### PR TITLE
Enable `Lint/MissingCopEnableDirective` cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -154,9 +154,6 @@ Lint/InterpolationCheck:
 Lint/LambdaWithoutLiteralBlock:
   Enabled: false
 
-Lint/MissingCopEnableDirective:
-  Enabled: false
-
 Lint/MixedRegexpCaptureTypes:
   Enabled: false
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1372,7 +1372,7 @@ Lint/Loop:
   Safe: false
 Lint/MissingCopEnableDirective:
   Description: Checks for a `# rubocop:enable` after `# rubocop:disable`.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.52'
   MaximumRangeSize: .inf
 Lint/MissingSuper:


### PR DESCRIPTION
This enables [Lint/MissingCopEnableDirective](https://docs.rubocop.org/rubocop/cops_lint.html#lintmissingcopenabledirective).