### PR TITLE
Enable TrailingCommaInArguments

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -698,7 +698,7 @@ Style/TrailingBodyOnMethodDefinition:
   Enabled: false
 
 Style/TrailingCommaInArguments:
-  Enabled: false
+  EnforcedStyleForMultiline: consistent_comma
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -17,7 +17,7 @@ class ConfigTest < Minitest::Test
       Rake::Task["config:dump"].invoke(tempfile.path)
 
       diff = Diffy::Diff.new(
-        original_config, tempfile.path, source: "files", context: 5
+        original_config, tempfile.path, source: "files", context: 5,
       ).to_s
 
       error_message = <<~ERROR

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3862,9 +3862,9 @@ Style/TrailingBodyOnModule:
 Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in argument lists.
   StyleGuide: "#no-trailing-params-comma"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.36'
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: consistent_comma
   SupportedStylesForMultiline:
   - comma
   - consistent_comma


### PR DESCRIPTION
Sets the same behaviour for trailing comma on all scenarios:
- arguments
- array literals
- hash literals

This particular cop was disabled in https://github.com/Shopify/ruby-style-guide/pull/18
with the main argument being the option `EnforcedStyleForMultiline` was binary (no comma vs comma).

Having the `consistent_comma` possibility, I think we can please everyone (🤞).
