### PR TITLE
Change `Style/NumericLiteralPrefix`'s `EnforcedOctalStyle` to `zero_with_o`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -597,9 +597,6 @@ Style/NumberedParameters:
 Style/NumberedParametersLimit:
   Enabled: false
 
-Style/NumericLiteralPrefix:
-  EnforcedOctalStyle: zero_only
-
 Style/NumericLiterals:
   Enabled: false
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3303,7 +3303,7 @@ Style/NumericLiteralPrefix:
   StyleGuide: "#numeric-literal-prefixes"
   Enabled: true
   VersionAdded: '0.41'
-  EnforcedOctalStyle: zero_only
+  EnforcedOctalStyle: zero_with_o
   SupportedOctalStyles:
   - zero_with_o
   - zero_only


### PR DESCRIPTION
While the [`zero_only` setting](https://docs.rubocop.org/rubocop/cops_style.html#stylenumericliteralprefix) allows the aesthetically pleasing use of two digit literals in times and dates

```ruby
Time.new(2000, 01, 01, 01, 01, 01) # Works because octal 01 == 1 in decimal
```

it doesn't work for `08` or `09`, and introduces a foot gun if developers assume leading zeros work in all cases

```ruby
price_in_cents         = 150 # $1.50
another_price_in_cents = 075 # 075 == 61, so $0.61, not $0.75!
```