### PR TITLE
Set Style/TrailingCommaInArguments's EnforcedStyleForMultiline to comma

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -709,7 +709,7 @@ Style/TrailingBodyOnMethodDefinition:
   Enabled: false
 
 Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: consistent_comma
+  EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -17,7 +17,7 @@ class ConfigTest < Minitest::Test
       Rake::Task["config:dump"].invoke(tempfile.path)
 
       diff = Diffy::Diff.new(
-        original_config, tempfile.path, source: "files", context: 5,
+        original_config, tempfile.path, source: "files", context: 5
       ).to_s
 
       error_message = <<~ERROR

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3887,7 +3887,7 @@ Style/TrailingCommaInArguments:
   StyleGuide: "#no-trailing-params-comma"
   Enabled: true
   VersionAdded: '0.36'
-  EnforcedStyleForMultiline: consistent_comma
+  EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
   - comma
   - consistent_comma


### PR DESCRIPTION
Differently from the Hash and Array versions of this rule, this one uses the existence of parentheses to determine if a comma is needed or not, not if the method is multiline. As our style guide require parentheses for all method calls, so this rule can't use the consistent_comma option.