### PR TITLE
Enforce sorted root config in `rubocop.yml`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -12,10 +12,10 @@ Bundler/OrderedGems:
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
 
-Gemspec/RequiredRubyVersion:
+Gemspec/RequireMFA:
   Enabled: false
 
-Gemspec/RequireMFA:
+Gemspec/RequiredRubyVersion:
   Enabled: false
 
 Layout/ArgumentAlignment:
@@ -364,11 +364,11 @@ Naming/VariableNumber:
 Security/CompoundHash:
   Enabled: false
 
-Security/MarshalLoad:
-  Enabled: false
-
 Security/IoMethods:
   Enabled: true
+
+Security/MarshalLoad:
+  Enabled: false
 
 Security/YAMLLoad:
   Enabled: false
@@ -400,6 +400,10 @@ Style/CaseLikeIf:
 
 Style/ClassEqualityComparison:
   Enabled: false
+
+Style/ClassMethodsDefinitions:
+  EnforcedStyle: self_class
+  Enabled: true
 
 Style/CollectionCompact:
   Enabled: false
@@ -737,7 +741,3 @@ Style/WordArray:
 
 Style/YodaCondition:
   Enabled: false
-
-Style/ClassMethodsDefinitions:
-  EnforcedStyle: self_class
-  Enabled: true

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -62,9 +62,24 @@ class ConfigTest < Minitest::Test
     assert(redundant_config.empty?, error_message)
   end
 
+  def test_config_is_sorted_alphabetically
+    config_keys = RuboCop::ConfigLoader.load_file("rubocop.yml").to_hash.keys
+    all_cops_index = config_keys.index("AllCops")
+    following_keys = config_keys[(all_cops_index + 1)..-1]
+
+    assert_sorted(following_keys, "Keys after AllCops in rubocop.yml must be sorted")
+  end
+
   private
 
   def checking_rubocop_version_compatibility?
     ENV.fetch("CHECKING_RUBOCOP_VERSION_COMPATIBILITY", "") == "true"
+  end
+
+  def assert_sorted(actual, message)
+    expected_string = actual.sort.join("\n")
+    actual_string = actual.join("\n")
+
+    assert_equal(expected_string, actual_string, message)
   end
 end


### PR DESCRIPTION
This adds a test enforcing that the config in `rubocop.yml` be sorted alphabetically (see https://github.com/Shopify/ruby-style-guide/pull/387#discussion_r924860912 for motivation).

Sorting is only enforced for configs starting with a capital letter appearing **after** `AllCops`, which should limit it to cop config. Other config such as `inherit_mode` should be unaffected.

Furthermore, nested key ordering is not enforced, since it makes sense for `Enabled` to appear first, and most of the value is in sorting the root entries anyway.

Note this only applies to our own `rubocop.yml`, and does not impact consumers or their `.rubocop.yml` files.