### PR TITLE
Bump to version for 2.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (2.10.1)
+    rubocop-shopify (2.11.0)
       rubocop (~> 1.41)
 
 GEM
@@ -27,17 +27,17 @@ GEM
     rake (13.0.6)
     regexp_parser (2.6.1)
     rexml (3.2.5)
-    rubocop (1.41.0)
+    rubocop (1.42.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.23.0, < 2.0)
+      rubocop-ast (>= 1.24.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.24.0)
+    rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.3.0)

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "2.10.1"
+  s.version     = "2.11.0"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Shopify's style guide for Ruby."


### PR DESCRIPTION
Increment minor version.

List of included changes:
* Change [Style/NumericLiteralPrefix](https://docs.rubocop.org/rubocop/cops_style.html#stylenumericliteralprefix)'s `EnforcedOctalStyle` to `zero_with_o` by @sambostock [#442](https://github.com/Shopify/ruby-style-guide/pull/442)
* Enabled [Lint/DuplicateMagicComment](https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicatemagiccomment), [Style/OperatorMethodCall](https://docs.rubocop.org/rubocop/cops_style.html#styleoperatormethodcall), and Style/[RedundantStringEscape](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantstringescape) introduced in Rubocop 1.37 by @sambostock [#452](https://github.com/Shopify/ruby-style-guide/pull/452)
* wip