### PR TITLE
Cut out version 2.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (2.10.1)
+    rubocop-shopify (2.11.0)
       rubocop (~> 1.42)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "2.10.1"
+  s.version     = "2.11.0"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Shopify's style guide for Ruby."


### PR DESCRIPTION
Depends on the Rubocop bump here https://github.com/Shopify/ruby-style-guide/pull/467

List of included changes:
* Bump rubocop to 1.42.0 (#467)
* Change [Style/NumericLiteralPrefix](https://docs.rubocop.org/rubocop/cops_style.html#stylenumericliteralprefix)'s `EnforcedOctalStyle` to `zero_with_o` by @sambostock in [#442](https://github.com/Shopify/ruby-style-guide/pull/442)
* Enable [Style/MinMaxComparison](https://docs.rubocop.org/rubocop/cops_style.html#styleminmaxcomparison) by @Korri in [#467](https://github.com/Shopify/ruby-style-guide/pull/467)
* Enable [Lint/DuplicateMagicComment](https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicatemagiccomment) by @sambostock in [#452](https://github.com/Shopify/ruby-style-guide/pull/452)
* Enable [Style/OperatorMethodCall](https://docs.rubocop.org/rubocop/cops_style.html#styleoperatormethodcall) by @sambostock in [#452](https://github.com/Shopify/ruby-style-guide/pull/452)
* Enable [Style/RedundantStringEscape](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantstringescape)  by @sambostock in [#452](https://github.com/Shopify/ruby-style-guide/pull/452)
* Enable [Style/RedundantEach](https://docs.rubocop.org/rubocop/cops_style.html#styleredundanteach) by @sambostock in [#457](https://github.com/Shopify/ruby-style-guide/pull/457)
* Enable [Style/ConcatArrayLiterals](https://docs.rubocop.org/rubocop/cops_style.html#styleconcatarrayliterals) by @sambostock in [#465](https://github.com/Shopify/ruby-style-guide/pull/465)
* Enable [Style/RedundantConstantBase](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantconstantbase) by @sambostock in [#465](https://github.com/Shopify/ruby-style-guide/pull/465)
* Enable [Style/RedundantDoubleSplatHashBraces](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantdoublesplathashbraces) by @sambostock in [#465](https://github.com/Shopify/ruby-style-guide/pull/465)
* Enforce Multiline Method calls, Arrays, and Hashes to use one line per element by @Korri in [#387](https://github.com/Shopify/ruby-style-guide/pull/387)

I _think_ I included everything, but this is a big one!

This will allow us to start bumping the gem in other repositories.