### PR TITLE
Disable Style/OperatorMethodCall and release 2.11.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (2.11.0)
+    rubocop-shopify (2.11.1)
       rubocop (~> 1.42)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "2.11.0"
+  s.version     = "2.11.1"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Shopify's style guide for Ruby."

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -648,7 +648,7 @@ Style/OpenStructUse:
   Enabled: true
 
 Style/OperatorMethodCall:
-  Enabled: true
+  Enabled: false
 
 Style/OptionalBooleanParameter:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3423,7 +3423,7 @@ Style/OpenStructUse:
 Style/OperatorMethodCall:
   Description: Checks for redundant dot before operator method call.
   StyleGuide: "#operator-method-call"
-  Enabled: true
+  Enabled: false
   VersionAdded: '1.37'
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.


### PR DESCRIPTION
This rule is causing (at least one) syntax error in code by replacing:
```ruby
T.unsafe(self).==(...)
```
by
```ruby
T.unsafe(self) == (...)
```

Which is not valid ruby