### PR TITLE
Re-enable `Style/OperatorMethodCall`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -663,7 +663,7 @@ Style/OpenStructUse:
   Enabled: true
 
 Style/OperatorMethodCall:
-  Enabled: false
+  Enabled: true
 
 Style/OptionalBooleanParameter:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3466,7 +3466,7 @@ Style/OpenStructUse:
 Style/OperatorMethodCall:
   Description: Checks for redundant dot before operator method call.
   StyleGuide: "#operator-method-call"
-  Enabled: false
+  Enabled: true
   VersionAdded: '1.37'
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.


### PR DESCRIPTION
Reverts Shopify/ruby-style-guide#474 and re-enables `Style/OperatorMethodCall`, following https://github.com/rubocop/rubocop/pull/11378 fixing the argument forwarding edge case.