### PR TITLE
Ignore lines made long by cop directive comments

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -64,7 +64,6 @@ Layout/LineEndStringConcatenationIndentation:
   EnforcedStyle: indented
 
 Layout/LineLength:
-  IgnoreCopDirectives: false
   AllowedPatterns:
   - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -714,7 +714,7 @@ Layout/LineLength:
   URISchemes:
   - http
   - https
-  IgnoreCopDirectives: false
+  IgnoreCopDirectives: true
   AllowedPatterns:
   - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
   IgnoredPatterns: []


### PR DESCRIPTION
This resets `Layout/LineLength`'s `IgnoreCopDirectives` to its default - `true` .

Assuming a config of `Max: 20`, for example purposes, this would be an offense based on our **current config**:

```ruby
const_get(something) # rubocop:disable Sorbet/ConstantsFromStrings                                                                                                                    
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

and the author would have to resort to the more verbose

```ruby
# rubocop:disable Sorbet/ConstantsFromStrings 
const_get(something)                                                                                                                    
# rubocop:enable Sorbet/ConstantsFromStrings
```

We already allow test descriptions to be long. I argue a similar justification applies here and that the inline version is better.

There is another alternative

```ruby
const_get(something) # rubocop:disable Sorbet/ConstantsFromStrings,Layout/LineLength
```

but that makes the line even longer than before, so I think it makes sense to just allow directives.