### PR TITLE
Allow `def test_...` lines to be long

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -66,6 +66,7 @@ Layout/LineEndStringConcatenationIndentation:
 Layout/LineLength:
   AllowedPatterns:
   - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
+  - "\\A\\s*def test_\\w+\\s*\\Z"
 
 Layout/MultilineArrayLineBreaks:
   Enabled: true

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -717,6 +717,7 @@ Layout/LineLength:
   IgnoreCopDirectives: true
   AllowedPatterns:
   - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
+  - "\\A\\s*def test_\\w+\\s*\\Z"
   IgnoredPatterns: []
 Layout/MultilineArrayBraceLayout:
   Description: Checks that the closing brace in an array literal is either on the


### PR DESCRIPTION
We currently allow lines like

```ruby
test "a really really ... really long test name" do
```

using the Active Support declarative test style to violate `Layout/LineLength`. It stands to reason we should also allow the equivalent Minitest style

```ruby
def test_a_really_really_..._really_long_test_name
```