### PR TITLE
Skip dumping config if required token is missing

### DIFF
--- a/.github/workflows/dump-config.yml
+++ b/.github/workflows/dump-config.yml
@@ -3,8 +3,22 @@ name: Dump config
 on: [push, pull_request]
 
 jobs:
+  check-token:
+    name: Check for token
+    runs-on: ubuntu-latest
+    outputs:
+      token-held: ${{ steps.set_output.outputs.token_held }}
+    steps:
+      - name: check for token
+        id: set_output
+        run: '[ -z "$TOKEN_HELD" ] || echo "token_held=true" >> "$GITHUB_OUTPUT"'
+        env:
+          TOKEN_HELD: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+
   dump-config:
     name: Dump config
+    needs: check-token
+    if: needs.check-token.outputs.token-held == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
We need a specific token to be able to make commits that will trigger other actions. However, Dependabot commits use different secrets and our token automation does not (yet) configure those.

Therefore, this makes dumping the config conditional on having the token. It is structured as a separate job due to limitations around the availability of secrets in `if` contexts, and to avoid having the conditional on every step.