### PR TITLE
Bump version to 2.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (2.12.0)
+    rubocop-shopify (2.13.0)
       rubocop (~> 1.50)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "2.12.0"
+  s.version     = "2.13.0"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to "\
     "the implementation of the Shopify's style guide for Ruby."


### PR DESCRIPTION
This bumps the gem version to `2.13` in preparation for the next release.

Draft release notes incoming...