### PR TITLE
Enable Style/ReturnNil cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -756,6 +756,9 @@ Style/RegexpLiteral:
 Style/RescueStandardError:
   Enabled: false
 
+Style/ReturnNil:
+  Enabled: true
+
 Style/SelectByRegexp:
   Enabled: false
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3774,7 +3774,7 @@ Style/RescueStandardError:
   - explicit
 Style/ReturnNil:
   Description: Use return instead of return nil.
-  Enabled: false
+  Enabled: true
   EnforcedStyle: return
   SupportedStyles:
   - return


### PR DESCRIPTION
Proposing we enable `Style/ReturnNil` to enforce `return if/unless condition` style over `return nil unless condition` as the `nil` component is redundant/unnecessary. Let's make this consistent.

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ReturnNil