### PR TITLE
Tweak `Naming/InclusiveLanguage` `AllowedRegex`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -372,8 +372,9 @@ Naming/InclusiveLanguage:
         - leader
       AllowedRegex:
         - !ruby/regexp '/master[_\s\.]key/' # Rails master key
-        - 'blob/master/'
-        - 'origin/master'
+        - !ruby/regexp /\w*:\/\/\S+/ # URLs (e.g. https://github.com/org/repo/blob/master/README.md)
+        - !ruby/regexp '/(?:blob|tree)/master/' # e.g. github.com/org/repo/blob/master/README.md, without https://
+        - !ruby/regexp '/origin[ \/]master/' # Legacy default git branch name
         - 'mastercard'
         - 'webmaster'
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -2113,8 +2113,9 @@ Naming/InclusiveLanguage:
       - leader
       AllowedRegex:
       - !ruby/regexp /master[_\s\.]key/
-      - blob/master/
-      - origin/master
+      - !ruby/regexp /\w*:\/\/\S+/
+      - !ruby/regexp /(?:blob|tree)\/master/
+      - !ruby/regexp /origin[ \/]master/
       - mastercard
       - webmaster
 Naming/MemoizedInstanceVariableName:


### PR DESCRIPTION
- Generalize to permitting all URLs, as they are generally out of the author's control (looks for `%r{\w*://\S+}`).
- Continue explicitly permitting `blob/master`, and add `tree/master`, in case of schemeless URL (`github.com/org/repo/blob/master/README`)
- Allow space between `origin` and `master`, in addition to `/`, to allow usage like `git pull origin master`.