### PR TITLE
Memoization strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1407,6 +1407,6 @@ end
 def merchant
   return @merchant if defined?(@merchant)
   
-  @merchant ||= Merchant.find_by(id: merchant_id)
+  @merchant = Merchant.find_by(id: merchant_id)
 end
 ~~~

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 * [Regular Expressions](#regular-expressions)
 * [Percent Literals](#percent-literals)
 * [Testing](#testing)
+* [Memoization](#memoization)
 
 ## General
 
@@ -1391,3 +1392,21 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
     do_something
   end
   ~~~
+  
+## Memoization
+
+* Prefer `return @x if defined?(@x)` over a simple `||=`
+
+~~~ ruby
+# bad - if the method is called N times, the query will also run N times
+def merchant
+  @merchant ||= Merchant.find_by(id: merchant_id)
+end
+
+# good - A single query, even when @merchant is nil
+def merchant
+  return @merchant if defined?(@merchant)
+  
+  @merchant ||= Merchant.find_by(id: merchant_id)
+end
+~~~

--- a/README.md
+++ b/README.md
@@ -1398,7 +1398,7 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 * Prefer `return @x if defined?(@x)` over a simple `||=`
 
 ~~~ ruby
-# bad - if the method is called N times, the query will also run N times
+# bad - if @merchant is assigned a falsy value (`nil`, `false`, `0`, etc) and is called N times, the query will also run N times
 def merchant
   @merchant ||= Merchant.find_by(id: merchant_id)
 end

--- a/README.md
+++ b/README.md
@@ -1398,7 +1398,7 @@ documentation](https://docs.rubocop.org/rubocop/configuration.html#inheriting-co
 * Prefer `return @x if defined?(@x)` over a simple `||=`
 
 ~~~ ruby
-# bad - if @merchant is assigned a falsy value (`nil`, `false`, `0`, etc) and is called N times, the query will also run N times
+# bad - if @merchant is assigned a falsy value (`nil` or `false`) and is called N times, the query will also run N times
 def merchant
   @merchant ||= Merchant.find_by(id: merchant_id)
 end


### PR DESCRIPTION
Memoization is useful if you want to run a command once but be able to access that value many times.

However, the popular `||=` operator is not great for when your command might return a falsey value. By guarding memoization instance methods with `if defined?`, we make sure it only runs once.

This is particularly important to stop expensive queries that may return `nil` or `false` from running needlessly.