### PR TITLE
Enable `Style/IfWithBooleanLiteralBranches`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -583,7 +583,7 @@ Style/IfUnlessModifier:
   Enabled: false
 
 Style/IfWithBooleanLiteralBranches:
-  Enabled: false
+  Enabled: true
 
 Style/InPatternThen:
   Enabled: true

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3009,7 +3009,7 @@ Style/IfUnlessModifierOfIfUnless:
   VersionChanged: '0.87'
 Style/IfWithBooleanLiteralBranches:
   Description: Checks for redundant `if` with boolean literal branches.
-  Enabled: false
+  Enabled: true
   VersionAdded: '1.9'
   SafeAutoCorrect: false
   AllowedMethods:


### PR DESCRIPTION
I find it really hard to find a reason for this rule to be disabled. It is very unlikely that in any situation a code like
`is_admin = current_user.is_admin? ? true : false` will be more readable than `is_admin = is_admin`

And even when the result is flipped  like `is_admin = current_user.ordinary_user? ? false : true` an alternative - `is_admin = !current_user.ordinary_user?` looks much more readable to me

To be honest I even disagree that we should have anything in `AllowedMethods` since I find `!!value.nonzero?` to be much more readable than `value.nonzero? ? true : false` 