### PR TITLE
Allow remaster in Naming/InclusiveLanguage

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -381,9 +381,7 @@ Naming/InclusiveLanguage:
         - !ruby/regexp /\w*:\/\/\S+/ # URLs (e.g. https://github.com/org/repo/blob/master/README.md)
         - !ruby/regexp '/(?:blob|tree)/master/' # e.g. github.com/org/repo/blob/master/README.md, without https://
         - !ruby/regexp '/origin[ \/]master/' # Legacy default git branch name
-        - 'mastercard'
-        - 'webmaster'
-        - 'remaster'
+        - !ruby/regexp '/(?<=[a-z])master|master(?=[a-z])/' # "master" substring within a longer word
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -2137,9 +2137,7 @@ Naming/InclusiveLanguage:
       - !ruby/regexp /\w*:\/\/\S+/
       - !ruby/regexp /(?:blob|tree)\/master/
       - !ruby/regexp /origin[ \/]master/
-      - mastercard
-      - webmaster
-      - remaster
+      - !ruby/regexp /(?<=[a-z])master|master(?=[a-z])/
 Naming/MemoizedInstanceVariableName:
   Description: Memoized method name should match memo instance variable name.
   Enabled: false


### PR DESCRIPTION
In the same spirit as 'Mastercard' and 'webmaster', 'remaster' (as in audiophonic or videographic remastering of older recordings etc) should be allowed as well.