### PR TITLE
Disable new cops by default

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,6 +5,7 @@ inherit_mode:
 
 AllCops:
   StyleGuideBaseURL: https://shopify.github.io/ruby-style-guide/
+  NewCops: disable # New cops will be triaged by style guide maintainers instead.
 
 Bundler/OrderedGems:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -74,7 +74,7 @@ AllCops:
   StyleGuideCopsOnly: false
   EnabledByDefault: false
   DisabledByDefault: false
-  NewCops: pending
+  NewCops: disable
   UseCache: true
   MaxFilesInCache: 20000
   CacheRootDirectory:


### PR DESCRIPTION
Shopify's Ruby Style Guide disallows pending cops. That is, any time the development version of Rubocop is updated, any new pending cops will fail CI until we explicitly enable or disable them.

However, due to time between releases, consumers having upgraded Rubocop may end up triaging cops themselves to get rid of the pending cops message.

Therefore, this switches the config to disable new cops by default, in favour of waiting for us to triage them. Of course, consumers can always choose to override individual cops, or even this entire setting.

---

🤔 This could be considered a breaking change, as the setting applies to all Rubocop cops, but we only triage and provide configuration for those in the main `rubocop` gem. This means that any apps wouldn't be warned about pending cops in plugins such as `rubocop-rails`.