### PR TITLE
Enforce `frozen_string_literal: true`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -548,6 +548,7 @@ Style/FormatStringToken:
 
 Style/FrozenStringLiteralComment:
   SafeAutoCorrect: true
+  EnforcedStyle: always_true
   Details: 'Add `# frozen_string_literal: true` to the top of the file. Frozen string
     literals will become the default in a future Ruby version, and we want to make
     sure we''re ready.'


### PR DESCRIPTION
The default `EnforcedStyle` is `always`, which enforces that all files have a `# frozen_string_literal` comment, but doesn't care if it's `true` or `false`. `always_true` enforces `true`, which we want. Any existing files can simply be added to a TODO list or disable the cop.