### PR TITLE
Consolidate Dependabot PRs for GitHub Actions & NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,16 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    groups:
+      all:
+        patterns:
+          - "*" # Update all GitHub Actions
 
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: monthly
+    groups:
+      all:
+        patterns:
+          - "*" # Update all npm dependencies


### PR DESCRIPTION
This will cause Dependabot to open:
- single PRs with all updates to GitHub Actions
- single PRs with all updates to NPM dependencies