### PR TITLE
Rename Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,15 @@ updates:
     schedule:
       interval: daily
     groups:
-      all:
+      actions:
         patterns:
-          - "*" # Update all GitHub Actions
+          - "*" # Update all GitHub Actions together
 
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: monthly
     groups:
-      all:
+      npm:
         patterns:
-          - "*" # Update all npm dependencies
+          - "*" # Update all npm dependencies together


### PR DESCRIPTION
This renames the groups introduced in #598 from "all" & "all to "actions" & "npm", respectively.