### PR TITLE
Allow long lines on spec titles too

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -73,7 +73,7 @@ Layout/LineEndStringConcatenationIndentation:
 
 Layout/LineLength:
   AllowedPatterns:
-  - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
+  - "\\A\\s*((remote_)?test|context|describe|it|pending|skip|xit)(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
   - "\\A\\s*def test_\\w+\\s*\\Z"
 
 Layout/MultilineArrayLineBreaks:

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -728,7 +728,7 @@ Layout/LineLength:
   - https
   IgnoreCopDirectives: true
   AllowedPatterns:
-  - "\\A\\s*(remote_)?test(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
+  - "\\A\\s*((remote_)?test|context|describe|it|pending|skip|xit)(_\\w+)?\\s.*(do|->)(\\s|\\Z)"
   - "\\A\\s*def test_\\w+\\s*\\Z"
 Layout/MultilineArrayBraceLayout:
   Description: Checks that the closing brace in an array literal is either on the


### PR DESCRIPTION
We allow long test titles of the form

```ruby
def test_really_long
```
```ruby
test "really long" do
```

This extends the `Regexp` to support `Minitest::Spec` and `RSpec` style tests

```ruby
describe "really long" do
  context "really long" do
    it "really long" do
```