### PR TITLE
Reduce minimum RuboCop version back to `~> 1.51`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-shopify (2.14.0)
-      rubocop (~> 1.53)
+      rubocop (~> 1.51)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/rubocop/shopify/gem_version_string_comparable_backport.rb
+++ b/lib/rubocop/shopify/gem_version_string_comparable_backport.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# This is true for Ruby 3.2+, so once support for 3.1 is dropped, we can remove this.
+# Until then, some installations may have a recent enough version of RubyGems, but it is not guaranteed.
+return if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.5.6")
+
+module RuboCop
+  module Shopify
+    # Backport rubygems/rubygems#5275, so we can compare `Gem::Version`s directly against `String`s.
+    #
+    #     Gem::Version.new("1.2.3") > "1.2"
+    #
+    # Without this, to support Ruby < 3.2, we would have to create a new `Gem::Version` instance ourselves.
+    #
+    #     Gem::Version.new("1.2.3") > Gem::Version.new("1.2")
+    #
+    # This would get very verbose in our RuboCop config files.
+    module GemVersionStringComparableBackport
+      def <=>(other)
+        return self <=> self.class.new(other) if (String === other) && self.class.correct?(other)
+
+        super
+      end
+
+      Gem::Version.prepend(self)
+    end
+  end
+end

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
 
-  s.add_dependency("rubocop", "~> 1.53")
+  s.add_dependency("rubocop", "~> 1.51")
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -202,8 +202,10 @@ Lint/LiteralAssignmentInCondition:
   Enabled: true
 <% end %>
 
+<% if rubocop_version >= "1.53" %>
 Lint/MixedCaseRange:
   Enabled: true
+<% end %>
 
 Lint/MixedRegexpCaptureTypes:
   Enabled: false
@@ -238,8 +240,10 @@ Lint/RaiseException:
 Lint/RedundantDirGlobSort:
   Enabled: false
 
+<% if rubocop_version >= "1.53" %>
 Lint/RedundantRegexpQuantifiers:
   Enabled: true
+<% end %>
 
 Lint/RedundantRequireStatement:
   Enabled: false
@@ -726,8 +730,10 @@ Style/RandomWithOffset:
 Style/RedundantArgument:
   Enabled: false
 
+<% if rubocop_version >= "1.52" %>
 Style/RedundantArrayConstructor:
   Enabled: true
+<% end %>
 
 Style/RedundantAssignment:
   Enabled: false
@@ -741,8 +747,10 @@ Style/RedundantConditional:
 Style/RedundantConstantBase:
   Enabled: true
 
+<% if rubocop_version >= "1.53" %>
 Style/RedundantCurrentDirectoryInPath:
   Enabled: true
+<% end %>
 
 Style/RedundantDoubleSplatHashBraces:
   Enabled: true
@@ -756,8 +764,10 @@ Style/RedundantFetchBlock:
 Style/RedundantFileExtensionInRequire:
   Enabled: false
 
+<% if rubocop_version >= "1.52" %>
 Style/RedundantFilterChain:
   Enabled: true
+<% end %>
 
 Style/RedundantHeredocDelimiterQuotes:
   Enabled: true
@@ -768,14 +778,18 @@ Style/RedundantInitialize:
 Style/RedundantLineContinuation:
   Enabled: true
 
+<% if rubocop_version >= "1.53" %>
 Style/RedundantRegexpArgument:
   Enabled: true
+<% end %>
 
 Style/RedundantRegexpCharacterClass:
   Enabled: false
 
+<% if rubocop_version >= "1.52" %>
 Style/RedundantRegexpConstructor:
   Enabled: true
+<% end %>
 
 Style/RedundantRegexpEscape:
   Enabled: false
@@ -801,8 +815,10 @@ Style/RescueStandardError:
 Style/ReturnNil:
   Enabled: true
 
+<% if rubocop_version >= "1.53" %>
 Style/ReturnNilInPredicateMethodDefinition:
   Enabled: true
+<% end %>
 
 Style/SelectByRegexp:
   Enabled: false
@@ -874,8 +890,10 @@ Style/UnpackFirst:
 Style/WordArray:
   EnforcedStyle: brackets
 
+<% if rubocop_version >= "1.53" %>
 Style/YAMLFileRead:
   Enabled: true
+<% end %>
 
 Style/YodaCondition:
   Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,8 +1,7 @@
 <%
+  require "rubocop/shopify/gem_version_string_comparable_backport"
+
   rubocop_version = Gem.loaded_specs.fetch("rubocop").version
-  v1_57 = Gem::Version.new("1.57")
-  v1_58 = Gem::Version.new("1.58")
-  v1_59 = Gem::Version.new("1.59")
 %>
 
 inherit_mode:
@@ -190,7 +189,7 @@ Lint/IncompatibleIoSelectWithFiberScheduler:
 Lint/InterpolationCheck:
   Enabled: false
 
-<% if rubocop_version >= v1_59 %>
+<% if rubocop_version >= "1.59" %>
 Lint/ItWithoutArgumentsInBlock:
   Enabled: true
 <% end %>
@@ -198,7 +197,7 @@ Lint/ItWithoutArgumentsInBlock:
 Lint/LambdaWithoutLiteralBlock:
   Enabled: false
 
-<% if rubocop_version >= v1_58 %>
+<% if rubocop_version >= "1.58" %>
 Lint/LiteralAssignmentInCondition:
   Enabled: true
 <% end %>
@@ -811,7 +810,7 @@ Style/SelectByRegexp:
 Style/SingleArgumentDig:
   Enabled: false
 
-<% if rubocop_version >= v1_57 %>
+<% if rubocop_version >= "1.57" %>
 Style/SingleLineDoEndBlock:
   Enabled: true
 <% end %>
@@ -840,7 +839,7 @@ Style/StringLiteralsInInterpolation:
 Style/StructInheritance:
   Enabled: false
 
-<% if rubocop_version >= v1_58 %>
+<% if rubocop_version >= "1.58" %>
 Style/SuperWithArgsParentheses:
   Enabled: true
 <% end %>


### PR DESCRIPTION
Since we're introducing the

```yaml
<% if rubocop_version >= "X.YZ" %>
Dept/Cop:
  Enabled: true
<% end %>
```

approach to configuring RuboCop without requiring a specific version of the gem (ahead of supporting plugin configs), we should just use that approach to avoid changing the minimum required version in the next release.

### ⚠️ Before Merging

- [x] Rebase after #613 is merged.