### PR TITLE
Add missing files to gemspec & bump version to `2.15.1`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (2.15.0)
+    rubocop-shopify (2.15.1)
       rubocop (~> 1.51)
 
 GEM

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "2.15.0"
+  s.version     = "2.15.1"
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to " \
     "the implementation of the Shopify's style guide for Ruby."


### PR DESCRIPTION
2.15.0 is broken because we're failing to include the backport patch which we try to `require` at the top of `rubocop.yml`.

This updates the `gempspec` to include all ruby files under `lib`, as well as the `README.md`. It also switches to use a wildcard to match the `rubocop.yml` and `rubocop-cli.yml` files, which will be useful when we add extension configs.

It also bumps the gem version so we can publish the fix.