### PR TITLE
Trigger Dependabot daily for gems instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: '/'
     versioning-strategy: increase
     schedule:
-      interval: weekly
+      interval: daily
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
We want to know about new RuboCop versions in a timely manner, and we don't have many dependencies, so we might as well check all of them daily.