### PR TITLE
Use Prism parser engine

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     rubocop-shopify (2.15.1)
-      rubocop (~> 1.51)
+      prism
+      rubocop (~> 1.62)
 
 GEM
   remote: https://rubygems.org/
@@ -32,7 +33,7 @@ GEM
     rake (13.1.0)
     regexp_parser (2.9.0)
     rexml (3.2.6)
-    rubocop (1.61.0)
+    rubocop (1.62.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -40,12 +41,11 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.0)
+    rubocop-ast (1.31.1)
       parser (>= 3.3.0.4)
-      prism (>= 0.24.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (2.5.0)
 

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
 
-  s.add_dependency("rubocop", "~> 1.51")
+  s.add_dependency("prism")
+  s.add_dependency("rubocop", "~> 1.62")
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -12,6 +12,7 @@ inherit_mode:
 AllCops:
   StyleGuideBaseURL: https://shopify.github.io/ruby-style-guide/
   NewCops: disable # New cops will be triaged by style guide maintainers instead.
+  ParserEngine: parser_prism
 
 Bundler/OrderedGems:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -80,6 +80,7 @@ AllCops:
   CacheRootDirectory:
   AllowSymlinksInCacheRootDirectory: false
   TargetRubyVersion:
+  ParserEngine: parser_prism
   SuggestExtensions:
     rubocop-rails:
     - rails


### PR DESCRIPTION
Once Prism support is stable in RuboCop, we'll likely want to default to enabling it.

As of https://github.com/rubocop/rubocop/releases/tag/v1.62.0, support is experimental, so we don't want to merge this yet.