### PR TITLE
Skip `rubocop` patch version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "rubocop"
+        # We only care about versions that might change config
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
We respond to RuboCop updates by updating our config accordingly (typically triaging new cops or changes to default config).

Since patch version updates shouldn't contain any such changes, we should be able to skip them and avoid the toil of triaging the PRs and audit them when compiling release notes.