### PR TITLE
Enable `Style/MixinUsage`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -645,9 +645,6 @@ Style/MinMaxComparison:
 Style/MixinGrouping:
   Enabled: false
 
-Style/MixinUsage:
-  Enabled: false
-
 Style/ModuleFunction:
   EnforcedStyle: extend_self
 

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3320,7 +3320,7 @@ Style/MixinGrouping:
   - grouped
 Style/MixinUsage:
   Description: Checks that `include`, `extend` and `prepend` exists at the top level.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.51'
 Style/ModuleFunction:
   Description: Checks for usage of `extend self` in modules.


### PR DESCRIPTION
This enables [`Style/MixinUsage`](https://docs.rubocop.org/rubocop/cops_style.html#stylemixinusage), which checks for

```ruby
include SomeModule # top level include!
```