### PR TITLE
Enable `Style/RedundantFileExtensionInRequire`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -748,9 +748,6 @@ Style/RedundantEach:
 Style/RedundantFetchBlock:
   Enabled: false
 
-Style/RedundantFileExtensionInRequire:
-  Enabled: false
-
 <% if rubocop_version >= "1.52" %>
 Style/RedundantFilterChain:
   Enabled: true

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3782,7 +3782,7 @@ Style/RedundantFileExtensionInRequire:
   Description: Checks for the presence of superfluous `.rb` extension in the filename
     provided to `require` and `require_relative`.
   StyleGuide: "#no-explicit-rb-to-require"
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.88'
 Style/RedundantFilterChain:
   Description: Identifies usages of `any?`, `empty?`, `none?` or `one?` predicate


### PR DESCRIPTION
This enables [`Style/RedundantFileExtensionInRequire`](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantfileextensioninrequire)

```ruby
# bad
require 'foo.rb'
require_relative '../foo.rb'

# good
require 'foo'
require_relative '../foo'
```