### PR TITLE
Disable Style/MethodCallWithArgsParentheses cop for migrations

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -635,6 +635,7 @@ Style/MethodCallWithArgsParentheses:
   - puts
   Exclude:
   - "/**/Gemfile"
+  - "/**/db/migrate/*"
 
 Style/MinMax:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -3256,6 +3256,7 @@ Style/MethodCallWithArgsParentheses:
   - omit_parentheses
   Exclude:
   - "/**/Gemfile"
+  - "/**/db/migrate/*"
 Style/MethodCallWithoutArgsParentheses:
   Description: Do not use parentheses for method calls with no arguments.
   StyleGuide: "#method-invocation-parens"


### PR DESCRIPTION
Same rationale as disabling this cop for Gemfile (the source is a DSL and reads worse with parentheses)