### PR TITLE
Add `dev.yml`

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,3 @@
+up:
+  - ruby
+  - bundler


### PR DESCRIPTION
This allows Shopify employees to quickly get this repo set up.

Contributors not using Shopify's internal tooling should install Ruby and gems using their preferred method.