### PR TITLE
Add Lint/NoReturnInMemoization cop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "diffy"
 gem "minitest"
 gem "pry-byebug"
 gem "rake"
+gem "rubocop-minitest"
 
 # Fixes the following warning on Ruby 3.3:
 #   base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,10 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.38.1)
       parser (>= 3.3.1.0)
+    rubocop-minitest (0.37.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
@@ -58,6 +62,7 @@ DEPENDENCIES
   minitest
   pry-byebug
   rake
+  rubocop-minitest
   rubocop-shopify!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     rubocop-shopify (2.15.1)
-      rubocop (~> 1.62)
+      lint_roller
+      rubocop (~> 1.72)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-shopify (2.15.1)
+    rubocop-shopify (3.0.0)
       lint_roller
       rubocop (~> 1.72)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,4 @@
+Lint/NoReturnInMemoization:
+  Enabled: true
+  VersionAdded: "3.0.0"
+  Description: "Checks for the use of a `return` with a value in `begin..end` blocks in the context of instance variable assignment such as memoization."

--- a/lib/rubocop-shopify.rb
+++ b/lib/rubocop-shopify.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "rubocop/cop/lint/no_return_in_memoization"

--- a/lib/rubocop-shopify.rb
+++ b/lib/rubocop-shopify.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
+require "rubocop/shopify/version"
+require "rubocop/shopify/plugin"
+
 require "rubocop/cop/lint/no_return_in_memoization"

--- a/lib/rubocop/cop/lint/no_return_in_memoization.rb
+++ b/lib/rubocop/cop/lint/no_return_in_memoization.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module RuboCop
+  module Cop
+    module Lint
+      # Checks for the use of a `return` with a value in `begin..end` blocks
+      # in the context of instance variable assignment such as memoization.
+      # Using `return` with a value in these blocks can lead to unexpected behavior
+      # as the `return` will exit the method that contains and not set the values
+      # of the instance variable.
+      #
+      # @example
+      #
+      #   # bad
+      #   def foo
+      #     @foo ||= begin
+      #       return 1 if bar
+      #       2
+      #     end
+      #   end
+      #
+      #   # bad
+      #   def foo
+      #     @foo = begin
+      #       return 1 if bar
+      #       2
+      #     end
+      #   end
+      #
+      #   # bad
+      #   def foo
+      #     @foo += begin
+      #       return 1 if bar
+      #       2
+      #     end
+      #   end
+      #
+      #   # bad - using return in rescue blocks still exits the method
+      #   def foo
+      #     @foo ||= begin
+      #       bar
+      #     rescue
+      #       return 2 if baz
+      #     end
+      #   end
+      #
+      #   # good
+      #   def foo
+      #     @foo ||= begin
+      #       if bar
+      #         1
+      #       else
+      #         2
+      #       end
+      #     end
+      #   end
+      #
+      #   # good - not an assignment to an instance variable
+      #   def foo
+      #     foo = begin
+      #       return 1 if bar
+      #       2
+      #     end
+      #   end
+      #
+      #   # good - proper exception handling without return
+      #   def foo
+      #     @foo ||= begin
+      #       bar
+      #     rescue
+      #       baz ? 2 : 3
+      #     end
+      #   end
+      class NoReturnInMemoization < ::RuboCop::Cop::Base
+        MSG = 'Do not `return` in `begin..end` blocks in instance variable assignment contexts.'
+
+        def on_or_asgn(node)
+          node.each_node(:kwbegin) do |kwbegin_node|
+            kwbegin_node.each_node(:return) do |return_node|
+              add_offense(return_node)
+            end
+          end
+        end
+
+        def on_op_asgn(node)
+          return unless node.assignment_node.ivasgn_type?
+
+          on_or_asgn(node)
+        end
+
+        alias on_ivasgn on_or_asgn
+        alias on_and_asgn on_or_asgn
+      end
+    end
+  end
+end

--- a/lib/rubocop/shopify/plugin.rb
+++ b/lib/rubocop/shopify/plugin.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "lint_roller"
+
+module RuboCop
+  module Shopify
+    class Plugin < LintRoller::Plugin
+      def about
+        LintRoller::About.new(
+          name: "rubocop-shopify",
+          version: RuboCop::Shopify::VERSION,
+          homepage: "https://github.com/Shopify/rubocop-shopify",
+          description: "A plugin for RuboCop to enforce Shopify-specific coding standards."
+        )
+      end
+
+      def supported?(context)
+        context.engine == :rubocop
+      end
+
+      def rules(context)
+        LintRoller::Rules.new(
+          type: :path,
+          config_format: :rubocop,
+          value: File.expand_path("../../../config/default.yml", __dir__)
+        )
+      end
+    end
+  end
+end

--- a/lib/rubocop/shopify/version.rb
+++ b/lib/rubocop/shopify/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Shopify
+    VERSION = "2.15.1"
+  end
+end

--- a/lib/rubocop/shopify/version.rb
+++ b/lib/rubocop/shopify/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Shopify
-    VERSION = "2.15.1"
+    VERSION = "3.0.0"
   end
 end

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "rubocop/shopify/version"
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rubocop-shopify"
-  s.version     = "2.15.1"
+  s.version     = RuboCop::Shopify::VERSION
   s.summary     = "Shopify's style guide for Ruby."
   s.description = "Gem containing the rubocop.yml config that corresponds to " \
     "the implementation of the Shopify's style guide for Ruby."
@@ -14,14 +19,16 @@ Gem::Specification.new do |s|
   s.email    = "gems@shopify.com"
   s.homepage = "https://shopify.github.io/ruby-style-guide/"
 
-  s.files = Dir["rubocop*.yml", "lib/**/*", "LICENSE.md", "README.md"]
+  s.files = Dir["rubocop*.yml", "lib/**/*", "LICENSE.md", "config/default.yml", "README.md"]
 
   s.metadata = {
     "source_code_uri" => "https://github.com/Shopify/ruby-style-guide/tree/v#{s.version}",
     "allowed_push_host" => "https://rubygems.org",
+    "default_lint_roller_plugin" => "RuboCop::Shopify::Plugin"
   }
 
   s.required_ruby_version = ">= 3.1.0"
 
-  s.add_dependency("rubocop", "~> 1.62")
+  s.add_dependency("rubocop", "~> 1.72")
+  s.add_dependency("lint_roller")
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -22,10 +22,8 @@ Bundler/OrderedGems:
 
 
 # Gemspec Department
-<% if rubocop_version >= "1.65" %>
 Gemspec/AddRuntimeDependency:
   Enabled: false
-<% end %>
 
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
@@ -113,10 +111,8 @@ Layout/HashAlignment:
 Layout/HeredocIndentation:
   Enabled: false
 
-<% if rubocop_version >= "1.67" %>
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
-<% end %>
 
 Layout/LineContinuationLeadingSpace:
   Enabled: true
@@ -185,10 +181,8 @@ Lint/AmbiguousRange:
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-<% if rubocop_version >= "1.71" %>
 Lint/ArrayLiteralInRegexp:
   Enabled: false
-<% end %>
 
 Lint/AssignmentInCondition:
   Enabled: false
@@ -202,15 +196,11 @@ Lint/ConstantDefinitionInBlock:
 Lint/ConstantOverwrittenInRescue:
   Enabled: true
 
-<% if rubocop_version >= "1.70" %>
 Lint/ConstantReassignment:
   Enabled: true
-<% end %>
 
-<% if rubocop_version >= "1.72" %>
 Lint/CopDirectiveSyntax:
   Enabled: true
-<% end %>
 
 Lint/DeprecatedConstants:
   Enabled: false
@@ -227,10 +217,8 @@ Lint/DuplicateMatchPattern:
 Lint/DuplicateRegexpCharacterClassElement:
   Enabled: true
 
-<% if rubocop_version >= "1.67" %>
 Lint/DuplicateSetElement:
   Enabled: true
-<% end %>
 
 Lint/EmptyBlock:
   Enabled: false
@@ -268,10 +256,8 @@ Lint/FormatParameterMismatch:
 Lint/HashCompareByIdentity:
   Enabled: false
 
-<% if rubocop_version >= "1.69" %>
 Lint/HashNewWithKeywordArgumentsAsDefault:
   Enabled: false
-<% end %>
 
 Lint/IdentityComparison:
   Enabled: false
@@ -318,10 +304,8 @@ Lint/NonLocalExitFromIterator:
 Lint/NumberedParameterAssignment:
   Enabled: false
 
-<% if rubocop_version >= "1.69" %>
 Lint/NumericOperationWithConstantResult:
   Enabled: true
-<% end %>
 
 Lint/OrAssignmentToConstant:
   Enabled: true
@@ -359,10 +343,8 @@ Lint/RedundantSafeNavigation:
 Lint/RedundantSplatExpansion:
   Enabled: false
 
-<% if rubocop_version >= "1.72" %>
 Lint/RedundantTypeConversion:
   Enabled: false
-<% end %>
 
 Lint/RefinementImportMethods:
   Enabled: false
@@ -403,10 +385,8 @@ Lint/ShadowedException:
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
 
-<% if rubocop_version >= "1.70" %>
 Lint/SharedMutableDefault:
   Enabled: false
-<% end %>
 
 Lint/StructNewOverride:
   Enabled: false
@@ -414,10 +394,8 @@ Lint/StructNewOverride:
 Lint/SuppressedException:
   Enabled: false
 
-<% if rubocop_version >= "1.72" %>
 Lint/SuppressedExceptionInNumberConversion:
   Enabled: false
-<% end %>
 
 Lint/SymbolConversion:
   Enabled: false
@@ -437,10 +415,8 @@ Lint/TripleQuotes:
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
-<% if rubocop_version >= "1.68" %>
 Lint/UnescapedBracketInRegexp:
   Enabled: false
-<% end %>
 
 Lint/UnexpectedBlockArity:
   Enabled: false
@@ -475,15 +451,11 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: false
 
-<% if rubocop_version >= "1.72" %>
 Lint/UselessConstantScoping:
   Enabled: false
-<% end %>
 
-<% if rubocop_version >= "1.69" %>
 Lint/UselessDefined:
   Enabled: false
-<% end %>
 
 Lint/UselessElseWithoutRescue:
   Enabled: false
@@ -491,10 +463,8 @@ Lint/UselessElseWithoutRescue:
 Lint/UselessMethodDefinition:
   Enabled: false
 
-<% if rubocop_version >= "1.66" %>
 Lint/UselessNumericOperation:
   Enabled: false
-<% end %>
 
 Lint/UselessRescue:
   Enabled: false
@@ -643,10 +613,8 @@ Style/Alias:
   Enabled: false
   EnforcedStyle: prefer_alias_method
 
-<% if rubocop_version >= "1.68" %>
 Style/AmbiguousEndlessMethodDefinition:
   Enabled: false
-<% end %>
 
 Style/AndOr:
   Enabled: false
@@ -672,10 +640,8 @@ Style/BeginBlock:
 Style/BisectedAttrAccessor:
   Enabled: false
 
-<% if rubocop_version >= "1.68" %>
 Style/BitwisePredicate:
   Enabled: false
-<% end %>
 
 Style/BlockComments:
   Enabled: false
@@ -721,10 +687,8 @@ Style/ColonMethodCall:
 Style/ColonMethodDefinition:
   Enabled: false
 
-<% if rubocop_version >= "1.68" %>
 Style/CombinableDefined:
   Enabled: false
-<% end %>
 
 Style/CombinableLoops:
   Enabled: false
@@ -754,10 +718,8 @@ Style/DataInheritance:
 Style/DefWithParentheses:
   Enabled: false
 
-<% if rubocop_version >= "1.69" %>
 Style/DigChain:
   Enabled: false
-<% end %>
 
 Style/Dir:
   Enabled: false
@@ -841,18 +803,14 @@ Style/FetchEnvVar:
 Style/FileEmpty:
   Enabled: false
 
-<% if rubocop_version >= "1.69" %>
 Style/FileNull:
   Enabled: false
-<% end %>
 
 Style/FileRead:
   Enabled: false
 
-<% if rubocop_version >= "1.69" %>
 Style/FileTouch:
   Enabled: false
-<% end %>
 
 Style/FileWrite:
   Enabled: false
@@ -900,16 +858,11 @@ Style/HashExcept:
 Style/HashLikeCase:
   Enabled: false
 
-<% if rubocop_version >= "1.71" %>
 Style/HashSlice:
   Enabled: false
-<% end %>
 
 Style/HashSyntax:
   Enabled: false
-<% if rubocop_version < "1.67" %>
-  EnforcedShorthandSyntax: either
-<% end %>
 
 Style/HashTransformKeys:
   Enabled: false
@@ -944,15 +897,11 @@ Style/InfiniteLoop:
 Style/InverseMethods:
   Enabled: false
 
-<% if rubocop_version >= "1.70" %>
 Style/ItAssignment:
   Enabled: false
-<% end %>
 
-<% if rubocop_version >= "1.68" %>
 Style/KeywordArgumentsMerging:
   Enabled: false
-<% end %>
 
 Style/KeywordParametersOrder:
   Enabled: false
@@ -973,10 +922,8 @@ Style/MagicCommentFormat:
 Style/MapCompactWithConditionalBlock:
   Enabled: false
 
-<% if rubocop_version >= "1.63" %>
 Style/MapIntoArray:
   Enabled: false
-<% end %>
 
 Style/MapToHash:
   Enabled: false
@@ -1196,10 +1143,8 @@ Style/RedundantFileExtensionInRequire:
 Style/RedundantFilterChain:
   Enabled: false
 
-<% if rubocop_version >= "1.72" %>
 Style/RedundantFormat:
   Enabled: false
-<% end %>
 
 Style/RedundantFreeze:
   Enabled: false
@@ -1213,10 +1158,8 @@ Style/RedundantInitialize:
 Style/RedundantInterpolation:
   Enabled: false
 
-<% if rubocop_version >= "1.66" %>
 Style/RedundantInterpolationUnfreeze:
   Enabled: false
-<% end %>
 
 Style/RedundantLineContinuation:
   Enabled: false
@@ -1276,10 +1219,8 @@ Style/ReturnNilInPredicateMethodDefinition:
 Style/SafeNavigation:
   Enabled: false
 
-<% if rubocop_version >= "1.68" %>
 Style/SafeNavigationChainLength:
   Enabled: false
-<% end %>
 
 Style/Sample:
   Enabled: false
@@ -1293,10 +1234,8 @@ Style/SelfAssignment:
 Style/Semicolon:
   Enabled: false
 
-<% if rubocop_version >= "1.64" %>
 Style/SendWithLiteralMethodName:
   Enabled: false
-<% end %>
 
 Style/SignalException:
   Enabled: false
@@ -1345,10 +1284,8 @@ Style/Strip:
 Style/StructInheritance:
   Enabled: false
 
-<% if rubocop_version >= "1.64" %>
 Style/SuperArguments:
   Enabled: false
-<% end %>
 
 Style/SuperWithArgsParentheses:
   Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -4,6 +4,9 @@
   rubocop_version = Gem.loaded_specs.fetch("rubocop").version
 %>
 
+plugins:
+  - rubocop-shopify
+
 inherit_mode:
   merge:
   - Exclude

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -290,7 +290,7 @@ Lint/MixedRegexpCaptureTypes:
   Enabled: false
 
 Lint/NoReturnInBeginEndBlocks:
-  Enabled: true
+  Enabled: false
 
 Lint/NonAtomicFileOperation:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1553,7 +1553,7 @@ Lint/NextWithoutAccumulator:
   VersionAdded: '0.36'
 Lint/NoReturnInBeginEndBlocks:
   Description: Do not `return` inside `begin..end` blocks in assignment contexts.
-  Enabled: true
+  Enabled: false
   VersionAdded: '1.2'
 Lint/NonAtomicFileOperation:
   Description: Checks for non-atomic file operations.

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -4523,6 +4523,11 @@ Style/ZeroLengthPredicate:
   Safe: false
   VersionAdded: '0.37'
   VersionChanged: '0.39'
+Lint/NoReturnInMemoization:
+  Enabled: true
+  VersionAdded: 3.0.0
+  Description: Checks for the use of a `return` with a value in `begin..end` blocks
+    in the context of instance variable assignment such as memoization.
 inherit_mode:
   merge:
   - Exclude

--- a/test/rubocop/cop/lint/no_return_in_memoization_test.rb
+++ b/test/rubocop/cop/lint/no_return_in_memoization_test.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rubocop/minitest/assert_offense"
+
+module RuboCop
+  module Cop
+    module Lint
+      class NoReturnInMemoizationTest < ::Minitest::Test
+        include ::RuboCop::Minitest::AssertOffense
+
+        def setup
+          @cop = NoReturnInMemoization.new
+        end
+
+        def test_returns_in_memoization_are_offenses
+          assert_offense(<<~RUBY)
+            def foo
+              @foo ||= begin
+                return 1 if bar
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+                2
+              end
+            end
+          RUBY
+        end
+
+        def test_returns_in_regular_assignment_are_not_offenses
+          assert_no_offenses(<<~RUBY)
+            def foo
+              foo = begin
+                return 1 if bar
+                2
+              end
+            end
+          RUBY
+        end
+
+        def test_returns_in_regular_assignment_for_instance_variable_are_offenses
+          assert_offense(<<~RUBY)
+            def foo
+              @foo = begin
+                return 1 if bar
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+                2
+              end
+            end
+          RUBY
+        end
+
+        def test_returns_in_operation_assignment_for_instance_variable_are_offenses
+          assert_offense(<<~RUBY)
+            def foo
+              @foo += begin
+                return 1 if bar
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+                2
+              end
+            end
+          RUBY
+
+          assert_offense(<<~RUBY)
+            def foo
+              @foo -= begin
+                return 1 if bar
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+                2
+              end
+            end
+          RUBY
+
+          assert_offense(<<~RUBY)
+            def foo
+              @foo *= begin
+                return 1 if bar
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+                2
+              end
+            end
+          RUBY
+
+          assert_offense(<<~RUBY)
+            def foo
+              @foo /= begin
+                return 1 if bar
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+                2
+              end
+            end
+          RUBY
+
+          assert_offense(<<~RUBY)
+            def foo
+              @foo **= begin
+                return 1 if bar
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+                2
+              end
+            end
+          RUBY
+
+          assert_offense(<<~RUBY)
+            def foo
+              @foo &&= begin
+                return 1 if bar
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+                2
+              end
+            end
+          RUBY
+        end
+
+        def test_returns_in_operation_assignment_for_instance_variable_are_not_offenses
+          assert_no_offenses(<<~RUBY)
+            def foo
+              foo += begin
+                return 1 if bar
+                2
+              end
+            end
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            def foo
+              foo -= begin
+                return 1 if bar
+                2
+              end
+            end
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            def foo
+              foo *= begin
+                return 1 if bar
+                2
+              end
+            end
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            def foo
+              foo /= begin
+                return 1 if bar
+                2
+              end
+            end
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            def foo
+              foo **= begin
+                return 1 if bar
+                2
+              end
+            end
+          RUBY
+        end
+
+        def test_returns_in_assignment_for_exception_handling_are_not_offenses
+          assert_no_offenses(<<~RUBY)
+            def foo
+              foo += begin
+                bar
+              rescue
+                return 2 if baz
+              end
+            end
+          RUBY
+        end
+
+        def test_returns_in_memoization_rescue_blocks_are_offenses
+          assert_offense(<<~RUBY)
+            def foo
+              @foo ||= begin
+                bar
+              rescue
+                return 2 if baz
+                ^^^^^^^^ Lint/NoReturnInMemoization: Do not `return` in `begin..end` blocks in instance variable assignment contexts.
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,8 @@
 require "minitest/autorun"
 require "pry-byebug"
 
+require "rubocop-shopify"
+
 module Warning
   class << self
     def warn(message)


### PR DESCRIPTION
Cop based on https://docs.rubocop.org/rubocop/cops_lint.html#lintnoreturninbeginendblocks, but with the difference that it only cares about instance variables, given sometimes using return inside `begin..end` blocks is idiomatic Ruby, like when handling exceptions.

Example of such case:

```ruby
def some_method
  some_value = begin
    get_external_api
  rescue ApiError
    return { error: "Api returned an error" }
  end

  do_something(some_value)
end
```

This cop checks for the use of `return` with a value in `begin..end` blocks in the context of instance variable assignment such as memoization. Using `return` with a value in these blocks can lead to unexpected behavior as the `return` will exit the method and not set the value of the instance variable.

```ruby
# bad
def foo
  @foo ||= begin
    return 1 if bar
    2
  end
end

# bad
def foo
  @foo = begin
    return 1 if bar
    2
  end
end

# bad
def foo
  @foo += begin
    return 1 if bar
    2
  end
end

# bad - using return in rescue blocks still exits the method
def foo
  @foo ||= begin
    bar
  rescue
    return 2 if baz
  end
end

# good
def foo
  @foo ||= begin
    if bar
      1
    else
      2
    end
  end
end

# good - not an assignment to an instance variable
def foo
  foo = begin
    return 1 if bar
    2
  end
end

# good - proper exception handling without return
def foo
  @foo ||= begin
    bar
  rescue
    baz ? 2 : 3
  end
end
```