### PR TITLE
Drop redundant `ruby-version` config

### DIFF
--- a/.github/workflows/dump-config.yml
+++ b/.github/workflows/dump-config.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4.1'
           bundler-cache: true
 
       - name: Dump config


### PR DESCRIPTION
This workflow does not use a matrix of Ruby versions, so we can drop the `ruby-version` config, which will result in the action using the existing `.ruby-version` file to select the version, removing the need to keep this file in sync.