### PR TITLE
Group all `*rubocop*` gem bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: daily
+    groups:
+      rubocop:
+        patterns:
+          - "*rubocop*"
     ignore:
       - dependency-name: "rubocop"
         # We only care about versions that might change config


### PR DESCRIPTION
This way we get the changelogs for all of them.

See https://github.com/Shopify/ruby-style-guide/pull/710#issuecomment-2749276762 for context.