### PR TITLE
Fix dump-config workflow commmit message newlines

### DIFF
--- a/.github/workflows/dump-config.yml
+++ b/.github/workflows/dump-config.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           add: 'test/fixtures/full_config.yml'
           default_author: github_actions
-          message: >
+          message: |
             Dump full RuboCop config
 
             This automated commit dumps the contents of the full RuboCop config.


### PR DESCRIPTION
We want the blank lines.

```diff
 Dump full RuboCop config
+
 This automated commit dumps the contents of the full RuboCop config.
+
 [dependabot skip]
```