### PR TITLE
Remove development dependency on `pry-byebug`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ gemspec
 
 gem "diffy"
 gem "minitest"
-gem "pry-byebug"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,25 +9,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    byebug (11.1.3)
-    coderay (1.1.3)
     diffy (3.4.3)
     json (2.10.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
-    method_source (1.0.0)
     minitest (5.25.5)
     parallel (1.26.3)
     parser (3.3.7.3)
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -60,7 +51,6 @@ PLATFORMS
 DEPENDENCIES
   diffy
   minitest
-  pry-byebug
   rake
   rubocop-shopify!
 

--- a/test/ruby_versions_test.rb
+++ b/test/ruby_versions_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "pry"
 require "yaml"
 
 class RubyVersionsTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
-require "pry-byebug"
 
 module Warning
   class << self


### PR DESCRIPTION
...in favour of out-of-the-box `irb` and `debug`.

Closes #716 