### PR TITLE
Drop `base64` development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,3 @@ gem "diffy"
 gem "minitest"
 gem "pry-byebug"
 gem "rake"
-
-# Fixes the following warning on Ruby 3.3:
-#   base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0.
-#   Add base64 to your Gemfile or gemspec. Also contact author of rubocop-1.53.0 to add base64 into its gemspec.
-# Check if this is still necessary when the minimum RuboCop version is increased.
-gem "base64"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    base64 (0.2.0)
     byebug (11.1.3)
     coderay (1.1.3)
     diffy (3.4.3)
@@ -59,7 +58,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  base64
   diffy
   minitest
   pry-byebug


### PR DESCRIPTION
This was added in #613 to address a warning when running with old RuboCop versions against new (at the time) Ruby versions.

This warning was addressed in rubocop/rubocop#12313 (released in [RuboCop 1.57.2](https://github.com/rubocop/rubocop/releases/tag/v1.57.2)), and as out minimum RuboCop version has surpassed that, we can remove the dependency.