### PR TITLE
Only update GitHub Actions weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly
     groups:
       actions:
         patterns:


### PR DESCRIPTION
`ruby/setup-ruby` has had lots of updates recently. We don't really need to be updating it daily though.