### PR TITLE
Backport handling `Naming/Predicate{Naming,Prefix}` rename

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -464,7 +464,11 @@ Naming/MethodName:
 Naming/MethodParameterName:
   Enabled: false
 
+<% if rubocop_version >= "1.76" %>
+Naming/PredicatePrefix:
+<% else %>
 Naming/PredicateName:
+<% end %>
   NamePrefix:
   - is_
   ForbiddenPrefixes:


### PR DESCRIPTION
This cop has been renamed, so we conditionally set the config depending on RuboCop version.

Backport from #736.
See #737 