### PR TITLE
Remove `rubocop-thread_safety`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     rubocop-shopify (3.0.0)
       lint_roller
       rubocop (~> 1.72, >= 1.72.1)
-      rubocop-thread_safety (>= 0.7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -42,9 +41,6 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-thread_safety (0.7.2)
-      lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)

--- a/rubocop-shopify.gemspec
+++ b/rubocop-shopify.gemspec
@@ -30,6 +30,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.2.0"
 
   s.add_dependency("rubocop", "~> 1.72", ">= 1.72.1")
-  s.add_dependency("rubocop-thread_safety", ">= 0.7.1")
   s.add_dependency("lint_roller")
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -4,7 +4,6 @@
 
 plugins:
   - rubocop-shopify
-  - rubocop-thread_safety
 
 inherit_mode:
   merge:
@@ -1406,14 +1405,3 @@ Style/YodaCondition:
 Style/ZeroLengthPredicate:
   Enabled: false
 
-ThreadSafety/ClassInstanceVariable:
-  Enabled: false
-
-ThreadSafety/MutableClassInstanceVariable:
-  Enabled: false
-
-ThreadSafety/NewThread:
-  Enabled: false
-
-ThreadSafety/RackMiddlewareInstanceVariable:
-  Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -4616,38 +4616,6 @@ Lint/NoReturnInMemoization:
   VersionAdded: 3.0.0
   Description: Checks for the use of a `return` with a value in `begin..end` blocks
     in the context of instance variable assignment such as memoization.
-ThreadSafety/ClassAndModuleAttributes:
-  Description: Avoid mutating class and module attributes.
-  Enabled: true
-  ActiveSupportClassAttributeAllowed: false
-ThreadSafety/ClassInstanceVariable:
-  Description: Avoid class instance variables.
-  Enabled: false
-ThreadSafety/MutableClassInstanceVariable:
-  Description: Do not assign mutable objects to class instance variables.
-  Enabled: false
-  EnforcedStyle: literals
-  SafeAutoCorrect: false
-  SupportedStyles:
-  - literals
-  - strict
-ThreadSafety/NewThread:
-  Description: Avoid starting new threads. Let a framework like Sidekiq handle the
-    threads.
-  Enabled: false
-ThreadSafety/DirChdir:
-  Description: Avoid using `Dir.chdir` due to its process-wide effect.
-  Enabled: true
-  AllowCallWithBlock: false
-ThreadSafety/RackMiddlewareInstanceVariable:
-  Description: Avoid instance variables in Rack middleware.
-  Enabled: false
-  Include:
-  - app/middleware/**/*.rb
-  - lib/middleware/**/*.rb
-  - app/middlewares/**/*.rb
-  - lib/middlewares/**/*.rb
-  AllowedIdentifiers: []
 inherit_mode:
   merge:
   - Exclude


### PR DESCRIPTION
After evaluating this plugin against real code, we have decided it is not worth including in this gem. Consumers can manually configure it as desired.