### PR TITLE
Enable `Lint/EmptyBlock`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -229,7 +229,7 @@ Lint/DuplicateSetElement:
   Enabled: true
 
 Lint/EmptyBlock:
-  Enabled: false
+  Enabled: true
 
 Lint/EmptyClass:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -1356,7 +1356,7 @@ Lint/ElseLayout:
   VersionChanged: '1.2'
 Lint/EmptyBlock:
   Description: Checks for blocks without a body.
-  Enabled: false
+  Enabled: true
   VersionAdded: '1.1'
   VersionChanged: '1.15'
   AllowComments: true


### PR DESCRIPTION
Hopefully a straight-forward proposal to enable `Lint/EmptyBlock`, in an effort to prevent situations like this:

```ruby
field :my_graphql_field, :string, null: true do |f|
  # something was here but removed by rudimentary automation
end
```