### PR TITLE
Enable `Lint/Void`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -495,10 +495,6 @@ Lint/UselessSetterCall:
 Lint/UselessTimes:
   Enabled: false
 
-Lint/Void:
-  Enabled: false
-
-
 # Metrics Department
 Metrics/AbcSize:
   Enabled: false

--- a/test/fixtures/full_config.yml
+++ b/test/fixtures/full_config.yml
@@ -2034,7 +2034,7 @@ Lint/UselessTimes:
   VersionChanged: '1.61'
 Lint/Void:
   Description: Possible use of operator/literal/variable in void context.
-  Enabled: false
+  Enabled: true
   AutoCorrect: contextual
   VersionAdded: '0.9'
   VersionChanged: '1.61'


### PR DESCRIPTION
`Lint/Void` isn't controversial at all, I don't remember it ever producing false-positives so it's useful and never requires any debates. So I propose we enable it. I'll link violations caught by this rule in our monolith, it made the code cleaner for most cases and for some cases fixed bugs